### PR TITLE
feat: add PR Title (clean) feat: add show password toggle in login and signup forms password toggle in login and signup forms

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -2,6 +2,8 @@ import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
 import { AuthContext } from "../context/AuthContext.jsx";
+import { Eye, EyeOff } from "lucide-react";
+
 
 const Login = () => {
   // two states for inputs
@@ -85,7 +87,7 @@ const Login = () => {
         />
       </div>
 
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1.5 relative">
         <label htmlFor="password" className="text-sm font-medium text-main">
           Password
         </label>
@@ -109,12 +111,14 @@ const Login = () => {
             input-focus
             hover-lift
           "
-        />
-        <button
+       />
+      <button
   type="button"
   onClick={() => setShowPassword(prev => !prev)}
+  aria-label={showPassword ? "Hide password" : "Show password"}
+  className="absolute right-3 top-1/2 -translate-y-1/2"
 >
-  {showPassword ? "Hide password" : "Show password"}
+  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
 </button>
       </div>
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -7,6 +7,7 @@ const Login = () => {
   // two states for inputs
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
   // useNavigate object
   const navigate = useNavigate();
@@ -89,7 +90,8 @@ const Login = () => {
           Password
         </label>
         <input
-          type="password"
+          type={showPassword?"text":"password"}
+          
           id="password"
           value={password}
           onChange={(e) => {
@@ -108,6 +110,12 @@ const Login = () => {
             hover-lift
           "
         />
+        <button
+  type="button"
+  onClick={() => setShowPassword(prev => !prev)}
+>
+  {showPassword ? "Hide password" : "Show password"}
+</button>
       </div>
 
       <button

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -2,6 +2,7 @@ import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
 import { AuthContext } from "../context/AuthContext.jsx";
+import { Eye, EyeOff } from "lucide-react";
 
 const Signup = () => {
   // three states for inputs
@@ -112,7 +113,7 @@ const Signup = () => {
         />
       </div>
 
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1.5 relative">
         <label htmlFor="password" className="text-sm font-medium text-main">
           Password
         </label>
@@ -135,11 +136,13 @@ const Signup = () => {
             input-focus hover-lift
           "
         />
-        <button
+       <button
   type="button"
   onClick={() => setShowPassword(prev => !prev)}
+  aria-label={showPassword ? "Hide password" : "Show password"}
+  className="absolute right-3 top-1/2 -translate-y-1/2"
 >
-  {showPassword ? "Hide password" : "Show password"}
+  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
 </button>
       </div>
 

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -8,6 +8,7 @@ const Signup = () => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
   // useNavigate object
   const navigate = useNavigate();
@@ -116,7 +117,7 @@ const Signup = () => {
           Password
         </label>
         <input
-          type="password"
+          type={showPassword ? "text" : "password"}
           id="password"
           value={password}
           onChange={(e) => {
@@ -134,6 +135,12 @@ const Signup = () => {
             input-focus hover-lift
           "
         />
+        <button
+  type="button"
+  onClick={() => setShowPassword(prev => !prev)}
+>
+  {showPassword ? "Hide password" : "Show password"}
+</button>
       </div>
 
       <button


### PR DESCRIPTION
📌 Description  

Added a show/hide password toggle for both Login and Signup forms to improve user experience and usability.

🔗 Related Issue

Closes #32

🛠 Changes Made
Added showPassword state in Login and Signup pages
Updated password input type to toggle between text and password
Added button to toggle password visibility
Ensured no form submission occurs when toggling

📸 Screenshots
Login Page
<img width="1911" height="962" alt="Screenshot (1341)" src="https://github.com/user-attachments/assets/77b5b359-d0cc-4fe4-a41d-06fdc99b91e3" /> <img width="1918" height="970" alt="Screenshot (1342)" src="https://github.com/user-attachments/assets/29d85478-94dc-4e6f-8fb8-e2f282871bce" />
Signup Page
<img width="1920" height="961" alt="Screenshot (1343)" src="https://github.com/user-attachments/assets/3dd66bba-6c10-47a0-a2de-d43ef9dc8a12" /> <img width="1904" height="969" alt="Screenshot (1344)" src="https://github.com/user-attachments/assets/53e698f2-210b-4125-9a17-12f04b58d51f" />

Checklist
 Code runs locally
 Followed project structure
 No console errors
 Properly tested changes
 Linked the issue

 Notes for Reviewers

This is a small UI improvement focused only on password visibility. No backend changes were made.