### PR TITLE
fix: remove redundant useTasks call in TaskPreview

### DIFF
--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -1,9 +1,8 @@
 import { useNavigate } from "react-router-dom";
-import useTasks from "../../hooks/useTasks";
 
-export default function TaskPreview({ tasks }) {
+
+export default function TaskPreview({ tasks , updateTask}) {
   const navigate = useNavigate();
-  const { updateTask } = useTasks();
 
   const priorityBorder = {
     Low: "border-green-400",

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -16,7 +16,7 @@ export default function Dashboard() {
   const [savedRoutines, setSavedRoutines] = useState([]);
   const [loadingRoutines, setLoadingRoutines] = useState(false);
 
-  const { tasks } = useTasks();
+  const { tasks, updateTask } = useTasks();
 
   const today = new Date();
 
@@ -106,7 +106,10 @@ export default function Dashboard() {
       <section className="flex animate-in delay-200 flex-col lg:flex-row gap-6 w-full">
         {/* Upcoming Tasks */}
         <div className="flex-1 animate-in delay-300">
-          <TaskPreview tasks={upcomingTasks} />
+          <TaskPreview
+              tasks={upcomingTasks}
+              updateTask={updateTask}
+          />
         </div>
 
         {/* Saved Routines */}


### PR DESCRIPTION
## Description
Removed the redundant useTasks() hook call from TaskPreview.jsx and passed updateTask from Dashboard.jsx as a prop to avoid an unnecessary API request.

## Related Issue
Closes #31 

## Changes Made
- Removed useTasks() import from TaskPreview
- Passed updateTask from Dashboard.jsx
- Eliminated duplicate GET /tasks request
- Verified toggle complete functionality still works

## Screenshots (if applicable)
No UI changes.

## Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## Notes for Reviewers
Anything specific you want reviewed.