### PR TITLE
fix: raise axios timeout and add user-friendly timeout error message

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -3,7 +3,7 @@ import axios from "axios";
 // create axios instance
 const api = axios.create({
   baseURL: "https://dailyforge-backend.onrender.com/api/",
-  timeout: 2000,
+  timeout: Number(import.meta.env.VITE_API_TIMEOUT) || 15000, // updated 15s as default
 });
 
 // attach jwt automatically with each request
@@ -23,5 +23,23 @@ api.interceptors.request.use((config) => {
     return Promise.reject(error);
   }
 });
+
+// Handle response errors, including timeout
+api.interceptors.response.use(
+  (response) => response, // success — pass through unchanged
+  (error) => {
+    if (error.code === "ECONNABORTED") {
+      // This fires when the timeout is hit
+      console.error("Request timed out. The server may be waking up from sleep. Please wait a moment and try again.");
+      error.userMessage =
+        "The server is waking up — this can take up to 30 seconds on first load. Please try again shortly.";
+    } else if (!error.response) {
+      // Network error (no internet, server completely unreachable)
+      console.error("Network error. Please check your connection.");
+      error.userMessage = "Network error. Please check your internet connection.";
+    }
+    return Promise.reject(error); // always reject so callers can handle it
+  }
+);
 
 export default api;


### PR DESCRIPTION
## 📌 Description
 Fixed the Axios request timeout from `2000ms` to `15000ms` and made it configurable using `VITE_API_TIMEOUT`, Added timeout-specific error handling for `ECONNABORTED` errors in the Axios response interceptor and attached a user-friendly `error.userMessage` so the UI can display a meaningful message.


## 🔗 Related Issue
Closes #19

## 🛠 Changes Made
- Raised `timeout` from `2000` to `15000ms` (configurable via `VITE_API_TIMEOUT`)
- Added `interceptors.response` to detect `ECONNABORTED` timeout errors
- Attaches `error.userMessage` so UI components can show a friendly message
- Preserved existing JWT request interceptor logic

---
### A timeout message can only be demonstrated by intentionally forcing a very low timeout value during testing, which is why I haven’t attached screenshots for this PR.

---
## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors
* [x] Properly tested changes
* [x] Linked the issue


## 🚀 Notes for Reviewers
Anything specific you want reviewed.