### PR TITLE
Add /api/health route to expose server uptime and MongoDB connection state

### DIFF
--- a/backend/routes/healthRoutes.js
+++ b/backend/routes/healthRoutes.js
@@ -1,0 +1,27 @@
+import express from "express";
+import mongoose from "mongoose";
+
+export const healthRouter = express.Router();
+
+// Mongoose readyState codes:
+// 0 = disconnected | 1 = connected | 2 = connecting | 3 = disconnecting
+const DB_STATES = {
+  0: "disconnected",
+  1: "connected",
+  2: "connecting",
+  3: "disconnecting",
+};
+
+// GET /api/health
+healthRouter.get("/", (_req, res) => {
+  const dbState = mongoose.connection.readyState;
+  const dbStatus = DB_STATES[dbState] ?? "unknown";
+  const isHealthy = dbState === 1;
+
+  return res.status(isHealthy ? 200 : 503).json({
+    status: isHealthy ? "ok" : "degraded",
+    db: dbStatus,
+    uptime: Math.floor(process.uptime()),
+    timestamp: new Date().toISOString(),
+  });
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,7 @@ import connectDB from "../config/db.js";
 import { authRouter } from "../routes/authRoutes.js";
 import { taskRouter } from "../routes/taskRoutes.js";
 import { routineRouter } from "../routes/routineRoutes.js";
+import { healthRouter } from "../routes/healthRoutes.js";
 
 // dotenv config
 dotenv.config();
@@ -35,6 +36,9 @@ app.use("/api/tasks", taskRouter);
 
 // Router for accessing routine routes
 app.use("/api/routines", routineRouter);
+
+// Router for health check
+app.use("/api/health", healthRouter);
 
 app.get("/", (req, res) => {
   res.send("Server running");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "DailyForge",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
@aryandas2911 

**Summary**
Resolves the missing health check endpoint by adding a dedicated GET /api/health route that reports live server and database status without requiring authentication.

**Changes**
New file backend/routes/healthRoutes.js — defines the health router, reads mongoose.connection.readyState on every request, and maps it to a human-readable status string
Modified backend/src/server.js — imports healthRouter and mounts it at /api/health

**Response Examples**

- When DB is connected — 200 OK

{
  "status": "ok",
  "db": "connected",
  "uptime": 142,
  "timestamp": "2026-05-13T02:20:00.000Z"
}

-  When DB is unreachable — 503 Service Unavailable

{
  "status": "degraded",
  "db": "disconnected",
  "uptime": 5,
  "timestamp": "2026-05-13T02:20:00.000Z"
}

**- Implementation Notes**

Returns 200 only when mongoose.connection.readyState === 1 (fully connected); all other states (disconnected, connecting, disconnecting) return 503 so uptime monitors flag them correctly
No authentication required — this route is intentionally public so external monitoring tools (e.g. UptimeRobot, Render health checks) can reach it
Follows the same router pattern as all existing route files (authRoutes.js, taskRoutes.js, routineRoutes.js)
uptime is in whole seconds via process.uptime()

**Testing**
Start the backend with a valid .env and hit the endpoint:
curl http://localhost:5000/api/health

Expected: 200 OK with "status": "ok" and "db": "connected".

To test the degraded path, temporarily set an invalid MONGO_URI in .env and restart — the endpoint should return 503 with "db": "disconnected".