### PR TITLE
feat: added optional description field to routines #62

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -14,7 +14,7 @@ export const createRoutine = async (req, res) => {
     }
 
     // fetch routine details from request body
-    const { name, items } = req.body;
+    const { name, description, items } = req.body;
     if (!name || items.length == 0 || !items) {
       return res
         .status(400)
@@ -74,6 +74,7 @@ export const createRoutine = async (req, res) => {
     const newRoutine = new Routine({
       userId,
       name,
+      description,
       items,
     });
 
@@ -111,7 +112,7 @@ export const getRoutines = async (req, res) => {
       createdAt: -1,
     });
     if (routines.length == 0) {
-      res.status(400).json({ message: "User has no routine", success: false });
+      return res.status(400).json({ message: "User has no routine", success: false });
     }
     return res.status(200).json({ success: true, routines });
   } catch (error) {
@@ -192,7 +193,7 @@ export const updateRoutine = async (req, res) => {
         message: "Routine not found",
       });
     }
-    res.status(200).json({
+    return res.status(200).json({
       message: "Routine updated successfully",
       routine: updatedRoutine,
     });
@@ -226,11 +227,11 @@ export const deleteRoutine = async (req, res) => {
       userId: userId,
     });
     if (!deleteRoutine) {
-      res.status(404).json({
+      return res.status(404).json({
         message: "Routine not found",
       });
     }
-    res.status(200).json({
+    return res.status(200).json({
       message: "Routine deleted successfully",
     });
   } catch (error) {

--- a/backend/src/models/Routine.js
+++ b/backend/src/models/Routine.js
@@ -11,6 +11,10 @@ const routineSchema = mongoose.Schema(
       type: String,
       required: true,
     },
+    description: {
+      type: String,
+      required: false,
+    },
     items: [ // tasks
       {
         taskId: {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -137,7 +137,12 @@ export default function Dashboard() {
                   className="border border-soft rounded-lg p-2 bg-white/80 shadow-sm hover-lift animate-in"
                 >
                   <p className="font-medium text-main">{routine.name}</p>
-                  <p className="text-xs text-muted">
+                  {routine.description && (
+                    <p className="text-xs text-muted mt-0.5 line-clamp-2 italic">
+                      {routine.description}
+                    </p>
+                  )}
+                  <p className="text-[10px] text-muted/80 mt-1 uppercase tracking-wider">
                     {routine.items.length} tasks across{" "}
                     {new Set(routine.items.map((i) => i.day)).size} day(s)
                   </p>

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -18,6 +18,7 @@ export default function RoutineBuilder() {
   const [routineName, setRoutineName] = useState("");
   const [savedRoutines, setSavedRoutines] = useState([]);
   const [loadingRoutines, setLoadingRoutines] = useState(false);
+  const [description, setDescription] = useState("");
 
   const handleSubmit = async (data) => {
     try {
@@ -62,11 +63,13 @@ export default function RoutineBuilder() {
     try {
       await api.post("/routines", {
         name: routineName,
+        description: description,
         items,
       });
 
       setIsSaveModalOpen(false);
       setRoutineName("");
+      setDescription("");
       setSelectedDay(null);
 
       alert("Routine saved successfully");
@@ -183,6 +186,12 @@ export default function RoutineBuilder() {
                       {routine.name}
                     </h3>
 
+                    {routine.description && (
+                      <p className="text-xs text-muted mb-3 italic">
+                        {routine.description}
+                      </p>
+                    )}
+
                     {Object.keys(tasksByDay).map((day) => (
                       <div key={day} className="mb-2">
                         <p className="text-sm font-semibold text-main">{day}</p>
@@ -234,6 +243,14 @@ export default function RoutineBuilder() {
               onChange={(e) => setRoutineName(e.target.value)}
               placeholder="Routine name"
               className="w-full mb-4 rounded-xl border-soft px-3 py-2 text-sm focus:outline-none"
+            />
+
+            <textarea
+              value={description}
+              onChange={(e)=> setDescription(e.target.value)}
+              placeholder="Add a description (optional)"
+              rows="3"
+              className="w-full mb-4 rounded-lg border-soft px-3 py-2 text-sm focus:ring-primary bg-white resize-none"
             />
 
             <div className="flex justify-end gap-3">


### PR DESCRIPTION
## 📌 Description
Added an optional description field to the Routine model and UI. This allows users to add extra context or notes to their routines

## 🔗 Related Issue
Closes #62

## 🛠 Changes Made
- Added description field (String) to the Routine schema in the backend.
- Updated the routine controller to handle saving and updating descriptions.
- Added a textarea to the "Save Routine" modal in the RoutineBuilder page.
- Updated the Dashboard and RoutineBuilder to display the description on routine cards.
- Fixed a logic issue where the backend would try to send multiple headers; added return statements to controller responses for better stability.

## 📸 Screenshots (if applicable)

<img width="1455" height="817" alt="Screenshot 2026-05-13 at 3 10 11 AM" src="https://github.com/user-attachments/assets/e68f4a52-aab4-4d8a-a3c7-3ca759d9c4a3" />
<img width="1455" height="821" alt="Screenshot 2026-05-13 at 3 11 23 AM" src="https://github.com/user-attachments/assets/a57353a1-2b62-4db9-8267-0707235f6abf" />


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
The description field is optional, so it won't break existing routines that don't have one. I also cleaned up the controller responses to stop the ERR_HTTP_HEADERS_SENT warnings that were appearing in the terminal.