### PR TITLE
Frontend and Backend env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,12 @@ cd backend
 npm install
 ```
 
-**Create your `.env` file** (see the [Environment Variables](#-environment-variables) section below):
+**Create your `.env` file from the given template** (see the [Environment Variables](#-environment-variables) section below):
 
 ```bash
 # Inside the /backend directory
-cp .env.example .env   # or manually create .env
+
+cp .env.example .env   
 ```
 
 Then fill in your values (see the next section for what each variable means).
@@ -210,7 +211,7 @@ cd frontend
 npm install
 ```
 
-> ⚠️ **Local dev note:** The frontend base URL is hardcoded in `frontend/src/api/axios.js` to point at the deployed backend. To test against your local backend, temporarily change `baseURL` in that file to `http://localhost:5000/api/`.
+> ⚠️ > 💡 **Local dev note:** To point the frontend to your local backend, copy `frontend/.env.example` to `frontend/.env` and ensure `VITE_API_URL` is set to `http://localhost:5000/api`.
 
 **Start the frontend dev server:**
 
@@ -232,7 +233,7 @@ Open `http://localhost:5173`, sign up for an account, and start building your ro
 
 ### Backend — `backend/.env`
 
-Create this file manually. **Never commit it to git.**
+Copy the provided template to get started. **Never commit the .env to git.**
 
 ```env
 PORT=5000
@@ -252,18 +253,12 @@ JWT_SECRET=your_super_secret_key_here
 3. Click **Connect** → **Connect your application** → Copy the connection string
 4. Replace `<password>` with your DB user's password
 
-### Frontend — No `.env` required
+### Frontend — `frontend/.env`
 
-The frontend has **no environment variables**. The API base URL is hardcoded in `frontend/src/api/axios.js`:
+Copy the provided .env.example to a new file .env 
 
-```js
-// frontend/src/api/axios.js
-const api = axios.create({
-  baseURL: "https://dailyforge-backend.onrender.com/api/",
-});
-```
 
-**Running locally?** Change `baseURL` to `http://localhost:5000/api/` while developing, and revert before committing.
+**Running locally?** Update `VITE_API_URL` in your local `.env` file to `http://localhost:5000/api/`.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+PORT=5000
+MONGO_URI=YOUR_MONGO_URI
+JWT_SECRET=developmentsupersecret
+FRONTEND_URL=http://localhost:5173

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Change this to http://localhost:5000/api for local development
+VITE_API_URL=https://dailyforge-backend.onrender.com/api/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 // create axios instance
 const api = axios.create({
-  baseURL: "https://dailyforge-backend.onrender.com/api/",
+  baseURL: import.meta.env.VITE_API_URL || "https://dailyforge-backend.onrender.com/api/",
   timeout: 2000,
 });
 


### PR DESCRIPTION
## 📌 Description
Refactored the frontend API configuration to use Vite Environment Variables instead of a hardcoded string. Added .env.example templates to both the frontend and backend folders to streamline the local setup process for new contributors.

## 🔗 Related Issue
Closes #100

## 🛠 Changes Made
- Replaced the hardcoded backend URL in frontend/src/api/axios.js with import.meta.env.VITE_API_URL.
- Created backend/.env.example and frontend/.env.example withe clear placeholders as per the README file.
- Updated README FIle to guide contributors through the env configurations.

## ✅ Checklist
- [ ✅] Code runs locally
- [✅ ] Followed project structure
- [✅  ] No console errors
- [ ✅ ] Properly tested changes
- [ ✅ ] Linked the issue
