### PR TITLE
feat: add character counter to task description

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -68,14 +68,32 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
 
           {/* Description */}
           <div>
-            <label className="text-sm font-medium text-main">Description</label>
+            <label className="text-sm font-medium text-main">
+              Description
+            </label>
+
             <textarea
               value={description}
-              onChange={(e) => setDescription(e.target.value)}
+              onChange={(e) =>
+                setDescription(e.target.value)
+              }
               className="w-full mt-1 p-2 border border-soft rounded-lg focus:ring-(--primary) focus:border-(--primary)"
               placeholder="Optional task description"
               rows={3}
+              maxLength={300}
             />
+
+            <p
+              className={`text-sm mt-1 text-right ${
+                description.length >= 300
+                  ? "text-red-500"
+                  : description.length >= 250
+                    ? "text-yellow-500"
+                    : "text-gray-500"
+              }`}
+            >
+              {description.length}/300
+            </p>
           </div>
 
           {/* Tags */}


### PR DESCRIPTION
## 📌 Description
Adds a real-time character counter below the task description textarea in TaskFormModal.

## 🔗 Related Issue
Closes #54

## 🛠 Changes Made
- Added live character counter for task descriptions
- Limited description input to 300 characters
- Added warning colors (yellow) as character count approaches the limit
- Added counter colour to red when it hits 300 characters

## 📸 Screenshots (if applicable)
<img width="803" height="870" alt="Screenshot 2026-05-12 233417" src="https://github.com/user-attachments/assets/1dcc58cc-8523-496e-b0b7-3c7701c50f49" />


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Implemented a real-time character counter for the task description textarea with a 300-character limit and warning color states near the limit and red colour state when the counter hits the limit