### PR TITLE
fix: remove static updatedAt default in Routine model

### DIFF
--- a/backend/src/models/Routine.js
+++ b/backend/src/models/Routine.js
@@ -41,10 +41,6 @@ const routineSchema = mongoose.Schema(
         },
       },
     ],
-    updatedAt: {
-      type: Date,
-      default: Date.now(),
-    },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Description
Removed the manually defined `updatedAt` field from the Routine schema in `Routine.js`. The field used `default: Date.now()`, which is evaluated **once** at module load time, causing every routine document to receive the same stale timestamp. Since the schema already uses `{ timestamps: true }`, Mongoose automatically manages both `createdAt` and `updatedAt` with accurate real-time values on every save and update.

## Related Issue
Closes #25

## Changes Made
- Removed the manual `updatedAt` field definition (lines 44–47) from `routineSchema` in `backend/src/models/Routine.js`
- `{ timestamps: true }` remains in schema options, ensuring Mongoose handles `updatedAt` automatically

## Screenshots (if UI changes)
N/A — backend-only change, no UI affected.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch follows the naming convention
- [x] I have tested this locally
- [x] Linting passes (`npm run lint` in frontend/)
- [x] No unrelated files were modified
- [x] Screenshots are attached (if UI change)
