### PR TITLE
fix: add interval overlap detection for task scheduling

### DIFF
--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -97,6 +97,23 @@ export default function RoutineBuilder() {
     const task = active.data.current?.task;
     if (!task) return;
     const { day, startTime } = over.data.current;
+    const duration = task.duration ?? 60;
+
+    // Check for overlap using interval comparison
+    const existingTask = scheduledTasks.find(
+      (t) =>
+        t.day === day &&
+        t.taskId !== task._id &&
+        startTime < t.startTime + t.duration &&
+        t.startTime < startTime + duration
+    );
+
+    if (existingTask) {
+      alert(
+        `Time conflict! "${existingTask.title}" already occupies this slot.`
+      );
+      return;
+    }
 
     setScheduledTasks((prev) => [
       ...prev.filter((t) => !(t.taskId === task._id && t.day === day)),
@@ -105,7 +122,7 @@ export default function RoutineBuilder() {
         title: task.title,
         day,
         startTime,
-        duration: 60,
+        duration,
       },
     ]);
   };


### PR DESCRIPTION
Replace same-slot equality check with interval-based overlap logic that considers task duration.

A 2-hour task at 9:00 AM and a task at 10:00 AM on the same day now correctly triggers a conflict warning instead of silently overlapping.

Also uses the task actual duration instead of hardcoding 60 minutes.

Fixes #92