### PR TITLE
fix: fail fast when MongoDB connection fails

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -5,8 +5,9 @@ const connectDB = async () => {
   try {
     await mongoose.connect(process.env.MONGO_URI);
     console.log("Connection to MongoDB successful");
-  } catch (_error) {
-    console.log("Error connecting to MongoDB");
+  } catch (error) {
+    console.error("Error connecting to MongoDB:", error.message);
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
## Summary
- Make MongoDB startup failures fatal by exiting with status code 1 when `connectDB` cannot connect.
- Log the actual connection error message so deployment logs are actionable.
- Preserve the existing successful connection confirmation log.

## Why
The server currently catches MongoDB connection errors and continues booting, which leaves the app running in an unhealthy state and causes later API calls to fail unpredictably.

Closes #27

## Validation
- `node --check backend/config/db.js`
- `npm run lint` from `backend/`
- `npm run test` from `backend/`
