### PR TITLE
feat: add routine calendar export functionality

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -1,6 +1,6 @@
 import Routine from "../src/models/Routine.js";
 import User from "../src/models/User.js";
-
+import { createEvents } from "ics";
 // Create routine function
 export const createRoutine = async (req, res) => {
   try {
@@ -122,6 +122,80 @@ export const getRoutines = async (req, res) => {
       .json({ success: false, message: "Error fetching routine" });
   }
 };
+
+
+// Export routines as ICS calendar file
+export const exportRoutineICS = async (req, res) => {
+  try {
+    const userId = req.userId;
+
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return res.status(401).json({
+        success: false,
+        message: "Unauthorized",
+      });
+    }
+
+    const routines = await Routine.find({ userId });
+
+    if (!routines.length) {
+      return res.status(404).json({
+        success: false,
+        message: "No routines found",
+      });
+    }
+
+    const events = [];
+
+    for (const routine of routines) {
+      for (const item of routine.items) {
+        const startHour = Math.floor(item.startTime / 60);
+        const startMinute = item.startTime % 60;
+
+        const endMinutes = item.startTime + item.duration;
+        const endHour = Math.floor(endMinutes / 60);
+        const endMinute = endMinutes % 60;
+
+        events.push({
+          title: `${routine.name} - ${item.day}`,
+          start: [2026, 5, 15, startHour, startMinute],
+          end: [2026, 5, 15, endHour, endMinute],
+        });
+      }
+    }
+
+    createEvents(events, (error, value) => {
+      if (error) {
+        console.log(error);
+
+        return res.status(500).json({
+          success: false,
+          message: "Error generating calendar file",
+        });
+      }
+
+      res.setHeader(
+        "Content-Disposition",
+        "attachment; filename=routines.ics"
+      );
+
+      res.setHeader("Content-Type", "text/calendar");
+
+      return res.send(value);
+    });
+  } catch (error) {
+    console.log("Error exporting routines", error);
+
+    return res.status(500).json({
+      success: false,
+      message: "Error exporting routines",
+    });
+  }
+};
+
+
 
 // Update routine function
 export const updateRoutine = async (req, res) => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "ics": "^3.12.0",
         "jsonwebtoken": "^9.0.3",
         "mongodb": "^7.0.0",
         "mongoose": "^9.0.0",
@@ -321,6 +322,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -735,6 +737,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1274,6 +1277,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ics": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/ics/-/ics-3.12.0.tgz",
+      "integrity": "sha512-BBPiZ/TbUyZrxui7SHKGOa/n2HUxaW9ucn7cw47NW9OSKe5tItYxIdN7Uczti5nKURmfwVvYi2aLigCJGH1+cA==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^3.1.23",
+        "runes2": "^1.1.2",
+        "yup": "^1.2.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1702,6 +1716,24 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1928,6 +1960,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2022,6 +2060,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/runes2": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/runes2/-/runes2-1.1.4.tgz",
+      "integrity": "sha512-LNPnEDPOOU4ehF71m5JoQyzT2yxwD6ZreFJ7MxZUAoMKNMY1XrAo60H1CUoX5ncSm0rIuKlqn9JZNRrRkNou2g==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2247,6 +2291,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2267,6 +2317,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
     },
     "node_modules/touch": {
       "version": "3.1.1",
@@ -2300,6 +2356,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -2415,6 +2483,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "ics": "^3.12.0",
     "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.0.0",
     "mongoose": "^9.0.0",

--- a/backend/routes/routineRoutes.js
+++ b/backend/routes/routineRoutes.js
@@ -1,10 +1,14 @@
 import express from "express";
+
 import {
   createRoutine,
   deleteRoutine,
+  exportRoutineICS,
   getRoutines,
   updateRoutine,
 } from "../controllers/routineController.js";
+
+
 import { authMiddleware } from "../middlewares/authMiddleware.js";
 
 // router object for routine
@@ -15,6 +19,8 @@ routineRouter.post("/", authMiddleware, createRoutine);
 
 // Route for fetching routines
 routineRouter.get("/", authMiddleware, getRoutines);
+
+routineRouter.get("/export", authMiddleware, exportRoutineICS);
 
 // Route for updating routine
 routineRouter.put("/:id", authMiddleware, updateRoutine);

--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -5,6 +5,42 @@ export default function TaskPreview({ tasks }) {
   const navigate = useNavigate();
   const { updateTask } = useTasks();
 
+  
+const handleExport = async () => {
+  try {
+    const token = localStorage.getItem("token");
+
+    const response = await fetch(
+      "http://localhost:5000/api/routines/export",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    const blob = await response.blob();
+
+    const url = window.URL.createObjectURL(blob);
+
+    const a = document.createElement("a");
+
+    a.href = url;
+    a.download = "routines.ics";
+
+    document.body.appendChild(a);
+
+    a.click();
+
+    a.remove();
+  } catch (error) {
+    console.log("Export failed", error);
+  }
+};
+
+
+
   const priorityBorder = {
     Low: "border-green-400",
     Medium: "border-yellow-400",
@@ -89,6 +125,33 @@ export default function TaskPreview({ tasks }) {
           View All Tasks →
         </button>
       </div>
+
+<div className="mt-4 flex flex-col sm:flex-row items-center gap-3 text-sm">
+  <button
+    onClick={() => navigate("/tasks")}
+    className="text-primary hover:underline cursor-pointer"
+  >
+    View All Tasks →
+  </button>
+
+  <button
+    onClick={handleExport}
+    className="
+      px-5 py-2 rounded-xl
+      bg-blue-500 text-white
+      hover:bg-blue-600
+      shadow-md hover:shadow-lg
+      transition-all duration-200
+      cursor-pointer
+      flex items-center gap-2
+    "
+  >
+    <span>Export Calendar</span>
+    <span>📅</span>
+  </button>
+</div>
+
+
     </div>
   );
 }


### PR DESCRIPTION
## ✨ Description

Added support for exporting routines as `.ics` calendar files so users can import their schedules into calendar apps.

## 🔗 Related Issue

Closes #223

## 🛠 Changes Made

* Added backend route for routine export
* Generated `.ics` files using routine data
* Added Export Calendar button to dashboard
* Enabled calendar file download from frontend

## 📸 Screenshots

Added working export calendar functionality.

## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors
* [x] Properly tested changes
* [x] Linked the issue

## 🚀 Notes for Reviewers

Export functionality has been tested locally and downloads a valid `.ics` calendar file.
