### PR TITLE
fix: normalize auth errors and controller flow

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -16,7 +16,7 @@ export const createTask = async (req, res) => {
     // fetch details for task from request body
     const { title, description, tags, priority, status, dueDate } = req.body;
     if (!title || !priority || !status) {
-      res
+      return res
         .status(400)
         .json({ success: false, message: "Please enter all the details" });
     }
@@ -62,7 +62,9 @@ export const getTasks = async (req, res) => {
     // fetch tasks from database
     const tasks = await Task.find({ userId: userId }).sort({ createdAt: -1 });
     if (tasks.length == 0) {
-      res.status(400).json({ message: "User has no task", success: false });
+      return res
+        .status(400)
+        .json({ message: "User has no task", success: false });
     }
     return res.status(200).json({ success: true, tasks });
   } catch (error) {
@@ -97,11 +99,11 @@ export const updateTask = async (req, res) => {
       { new: true, runValidators: true }
     );
     if (!updatedTask) {
-      res.status(404).json({
+      return res.status(404).json({
         message: "Task not found",
       });
     }
-    res.status(200).json({
+    return res.status(200).json({
       message: "Task updated successfully",
       task: updatedTask,
     });
@@ -121,7 +123,7 @@ export const deleteTask = async (req, res) => {
     const userId = req.userId;
     const user = await User.findById(userId);
     if (!user) {
-      res
+      return res
         .status(401)
         .json({ success: false, message: "Unauthorized, token invalid" });
     }
@@ -135,11 +137,11 @@ export const deleteTask = async (req, res) => {
       userId: userId,
     });
     if (!deleteTask) {
-      res.status(404).json({
+      return res.status(404).json({
         message: "Task not found",
       });
     }
-    res.status(200).json({
+    return res.status(200).json({
       message: "Task deleted successfully",
     });
   } catch (error) {

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -7,6 +7,7 @@ export const authMiddleware = (req, res, next) => {
     return res.status(401).json({
       success: false,
       message: "Authorization error, token not present",
+      data: null,
     });
   }
 
@@ -15,7 +16,7 @@ export const authMiddleware = (req, res, next) => {
   if (!token) {
     return res
       .status(401)
-      .json({ success: false, message: "Token format invalid" });
+      .json({ success: false, message: "Token format invalid", data: null });
   }
 
   try {
@@ -29,6 +30,10 @@ export const authMiddleware = (req, res, next) => {
   } catch (error) {
     // error handling
     console.log("Token verification error", error);
-    return res.status(500).json({ success: false, message: "Token invalid" });
+    return res.status(401).json({
+      success: false,
+      message: "Token invalid",
+      data: null,
+    });
   }
 };


### PR DESCRIPTION
## Description
Fixes auth middleware to return 401 for invalid/expired JWTs and ensures task controller error responses return immediately.

## Related Issue
Closes #292 #288

## Changes Made
- Return 401 with consistent payload for invalid JWTs in auth middleware
- Add missing `return` statements after error responses in task controller

## Screenshots (if UI changes)
N/A (no UI changes)

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch follows the naming convention
- [x] I have tested this locally
- [x] Linting passes (`npm run lint` in frontend/)
- [x] No unrelated files were modified

## Notes for Reviewers
Please focus on auth status codes and controller flow control.