### PR TITLE
fix: replace same-slot check with interval overlap detection

### DIFF
--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -7,6 +7,7 @@ import useTasks from "../hooks/useTasks.js";
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import api from "../api/axios.js";
+import { hasConflict } from "../utils/conflictUtils";
 
 export default function RoutineBuilder() {
   const { addTask, tasks } = useTasks();
@@ -90,25 +91,32 @@ export default function RoutineBuilder() {
   };
 
   /* ---------------- DRAG END HANDLER ---------------- */
-  const handleDragEnd = (event) => {
-    const { active, over } = event;
-    if (!over) return;
+const handleDragEnd = (event) => {
+  const { active, over } = event;
+  if (!over) return;
 
-    const task = active.data.current?.task;
-    if (!task) return;
-    const { day, startTime } = over.data.current;
+  const task = active.data.current?.task;
+  if (!task) return;
+  const { day, startTime } = over.data.current;
 
-    setScheduledTasks((prev) => [
-      ...prev.filter((t) => !(t.taskId === task._id && t.day === day)),
-      {
-        taskId: task._id,
-        title: task.title,
-        day,
-        startTime,
-        duration: 60,
-      },
-    ]);
+  const newTask = {
+    taskId: task._id,
+    title: task.title,
+    day,
+    startTime,
+    duration: task.duration ?? 60,
   };
+
+
+  const filtered = scheduledTasks.filter((t) => t.taskId !== task._id);
+
+  if (hasConflict(newTask, filtered)) {
+    alert(`"${task.title}" overlaps with an existing task on ${day}!`);
+    return;
+  }
+
+  setScheduledTasks([...filtered, newTask]);
+};
 
   return (
     <DndContext onDragEnd={handleDragEnd}>

--- a/frontend/src/utils/conflictUtils.js
+++ b/frontend/src/utils/conflictUtils.js
@@ -1,0 +1,14 @@
+export const overlaps = (a, b) => {
+  const aDur = a.duration ?? 60;
+  const bDur = b.duration ?? 60;
+  return (
+    a.day === b.day &&
+    a.startTime < b.startTime + bDur &&
+    b.startTime < a.startTime + aDur
+  );
+};
+
+export const hasConflict = (newTask, existingTasks) =>
+  existingTasks
+    .filter((t) => t.taskId !== newTask.taskId)
+    .some((t) => overlaps(t, newTask));


### PR DESCRIPTION
## Description
Fixes overlap detection that only caught tasks at the exact same start time. Replaces equality check with interval overlap logic so tasks with duration are correctly validated against each other.

## Related Issue
Closes #92

## Changes Made
- Created `frontend/src/utils/conflictUtils.js` with two helper functions:
  `overlaps()` checks if two tasks clash in time, `hasConflict()` checks
  new task against all existing tasks on the grid
- Updated `handleDragEnd` in `RoutineBuilder.jsx` to use interval overlap
  logic instead of checking only for exact same start time
- Fixed duration being hardcoded to 60 minutes — now reads actual task
  duration with 60 as fallback
- Moved conflict check outside `setScheduledTasks` to prevent React
  StrictMode from firing the alert twice on each drop

## Screenshots 
<img width="1600" height="841" alt="dailyforge" src="https://github.com/user-attachments/assets/885e94c7-6fb2-4c4a-9665-4b7343d15208" />


## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch follows the naming convention
- [x] I have tested this locally
- [x] Linting passes
- [x] No unrelated files were modified
- [x] Screenshots are attached 
