### PR TITLE
Add dark/light mode toggle in navbar

### DIFF
--- a/frontend/src/components/Dashboard/DashboardTasks.jsx
+++ b/frontend/src/components/Dashboard/DashboardTasks.jsx
@@ -61,7 +61,7 @@ export default function DashboardTasks() {
               key={task._id}
               className={`group relative flex items-center gap-4 border-l-4 rounded-xl p-4 transition-all duration-200
               ${priorityBorder[task.priority]}
-              bg-white/80 hover:bg-white shadow-sm hover:shadow-md`}
+              surface-bg hover:shadow-md shadow-sm`}
             >
               {/* Checkbox */}
               <input

--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -18,7 +18,7 @@ export default function TaskPreview({ tasks }) {
   };
 
   return (
-    <div className="bg-(--surface) rounded-2xl shadow-lg p-6 border border-white/10">
+    <div className="surface-bg rounded-2xl shadow-lg p-6 border-soft">
       <h2 className="text-lg font-semibold text-main mb-4">Upcoming Tasks</h2>
 
       {tasks?.length ? (
@@ -28,7 +28,7 @@ export default function TaskPreview({ tasks }) {
               key={task._id}
               className={`flex items-center gap-4 border-l-4 rounded-xl p-4 transition
               ${priorityBorder[task.priority]}
-              bg-white/80 hover:bg-white shadow-sm`}
+              surface-bg shadow-sm`}
             >
               {/* Checkbox */}
               <input

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,9 +1,12 @@
 import { useContext } from "react";
 import { Link } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
+import { Sun, Moon } from "lucide-react";
 
 const Navbar = () => {
   const { token, logout } = useContext(AuthContext);
+  const { isDark, toggleTheme } = useTheme();
 
   return (
     <nav className="surface-bg fixed top-0 z-20 w-full border-soft shadow-sm">
@@ -13,6 +16,20 @@ const Navbar = () => {
         </Link>
 
         <div className="flex items-center gap-4">
+          {/* Dark/Light Mode Toggle */}
+          <button
+            onClick={toggleTheme}
+            className="p-2 rounded-xl transition-all duration-200 cursor-pointer hover:bg-[var(--accent)]/20"
+            aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+            title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {isDark ? (
+              <Sun size={20} className="text-main" />
+            ) : (
+              <Moon size={20} className="text-main" />
+            )}
+          </button>
+
           {!token ? (
             <>
               <Link

--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -39,7 +39,7 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
 
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 animate-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-6 relative animate-in delay-100">
+      <div className="surface-bg rounded-2xl shadow-xl w-full max-w-md p-6 relative animate-in delay-100">
         {/* Close Button */}
         <button
           onClick={onClose}

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+// create theme context
+// eslint-disable-next-line react-refresh/only-export-components
+export const ThemeContext = createContext(null);
+
+// custom hook
+// eslint-disable-next-line react-refresh/only-export-components
+export const useTheme = () => useContext(ThemeContext);
+
+// provider component
+const ThemeProvider = ({ children }) => {
+  const [isDark, setIsDark] = useState(() => {
+    const saved = localStorage.getItem("theme");
+    return saved === "dark";
+  });
+
+  // toggle function
+  const toggleTheme = () => {
+    setIsDark((prev) => !prev);
+  };
+
+  // sync with DOM and localStorage
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      root.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }, [isDark]);
+
+  return (
+    <ThemeContext.Provider value={{ isDark, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeProvider;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,6 +29,26 @@
   --radius: 0.75rem;
 }
 
+/* Dark theme overrides */
+.dark {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --primary: #4eb7b3;
+  --primary-hover: #6dd5c7;
+  --accent: #2d4a5a;
+  --text-main: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: #334155;
+}
+
+/* Smooth theme transition */
+*,
+*::before,
+*::after {
+  transition: background-color 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease;
+}
+
 /* Utility Classes */
 @layer utilities {
   /* Layout backgrounds */

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
 import AuthProvider from "./context/AuthContext.jsx";
+import ThemeProvider from "./context/ThemeContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ThemeProvider>
   </StrictMode>
 );

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -110,7 +110,7 @@ export default function Dashboard() {
         </div>
 
         {/* Saved Routines */}
-        <div className="flex-1 animate-in delay-300 flex flex-col bg-white/80 rounded-xl shadow-md p-4 h-74 overflow-y-auto relative">
+        <div className="flex-1 animate-in delay-300 flex flex-col surface-bg rounded-xl shadow-md p-4 h-74 overflow-y-auto relative">
           {/* Header with button */}
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-lg font-semibold text-main">Saved Routines</h2>
@@ -134,7 +134,7 @@ export default function Dashboard() {
               {savedRoutines.map((routine) => (
                 <li
                   key={routine._id}
-                  className="border border-soft rounded-lg p-2 bg-white/80 shadow-sm hover-lift animate-in"
+                  className="border border-soft rounded-lg p-2 surface-bg shadow-sm hover-lift animate-in"
                 >
                   <p className="font-medium text-main">{routine.name}</p>
                   <p className="text-xs text-muted">


### PR DESCRIPTION
## Description

Added a dark/light mode toggle button (Sun/Moon icon) on the right side of the Navbar, allowing users to switch between light and dark themes.

Closes #<your-issue-number>

---

#  Changes Made

##  New File

### `frontend/src/context/ThemeContext.jsx`
Created a new React Context that:

- Manages theme state (`isDark`)
- Provides a `toggleTheme()` function
- Persists user preference using `localStorage`
- Toggles a `.dark` class on the `<html>` element

---

#  Modified Files

| File | Changes |
|------|----------|
| `frontend/src/index.css` | Added `.dark` class with dark theme CSS variable overrides and smooth theme transitions |
| `frontend/src/components/Navbar.jsx` | Added Sun/Moon toggle button using `lucide-react` before Login/Logout buttons |
| `frontend/src/main.jsx` | Wrapped the application with `<ThemeProvider>` |
| `frontend/src/pages/Dashboard.jsx` | Replaced hardcoded `bg-white` with theme-compatible surface background |
| `frontend/src/components/Dashboard/DashboardTasks.jsx` | Updated card background styling for dark mode compatibility |
| `frontend/src/components/Dashboard/TaskPreview.jsx` | Updated card background styling for dark mode compatibility |
| `frontend/src/components/Task/TaskFormModal.jsx` | Updated modal background styling for dark mode compatibility |

---

# Icons Used

Used existing `lucide-react` icons:

- `Sun`
- `Moon`

---

# Features Implemented

- [x] Dark/Light mode toggle added in Navbar
- [x] Theme switching works globally
- [x] Theme persists after page reload
- [x] Smooth CSS transition between themes
- [x] Dashboard and task components support dark mode
- [x] No new dependencies added

---

# Screenshots

## Light Mode
<img width="1914" height="164" alt="Screenshot 2026-05-15 230554" src="https://github.com/user-attachments/assets/0db65c4d-ba28-420a-828d-22cf04a875a6" />


## Dark Mode
<img width="1905" height="905" alt="Screenshot 2026-05-15 231326" src="https://github.com/user-attachments/assets/5b4a4f92-4cbd-47c9-99ce-b5ce413afab0" />

<img width="1762" height="958" alt="image" src="https://github.com/user-attachments/assets/53568a1d-5984-48e3-a8fb-e6f9a5e0f8e9" />



---

# 🧪 Testing Done

- Verified theme toggles correctly
- Checked persistence using `localStorage`
- Tested Dashboard, Tasks, and Modal components in both themes
- Verified responsive behavior on different screen sizes

Closes #299 