### PR TITLE
Add password validation on signup (frontend + backend)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -8,6 +8,13 @@ export const signup = async (req, res) => {
     // fetch values from request
     const { name, email, password } = req.body;
 
+    // validate password length
+    if (!password || password.length < 6) {
+      return res
+        .status(400)
+        .json({ message: "Password must be at least 6 characters" });
+    }
+
     // check user exists or not
     const checkExisting = await User.findOne({ email });
     if (checkExisting) {

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -8,6 +8,7 @@ const Signup = () => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [passwordError, setPasswordError] = useState("");
 
   // useNavigate object
   const navigate = useNavigate();
@@ -19,6 +20,13 @@ const Signup = () => {
   const handleSubmit = async (e) => {
     // prevents page from refreshing
     e.preventDefault();
+
+    // validate password length before sending to server
+    if (password.length < 6) {
+      setPasswordError("Password must be at least 6 characters");
+      return;
+    }
+    setPasswordError("");
 
     // send request to server
     try {
@@ -121,19 +129,28 @@ const Signup = () => {
           value={password}
           onChange={(e) => {
             setPassword(e.target.value);
+            if (e.target.value.length > 0 && e.target.value.length < 6) {
+              setPasswordError("Password must be at least 6 characters");
+            } else {
+              setPasswordError("");
+            }
           }}
           placeholder="••••••••"
           required
-          className="
+          minLength={6}
+          className={`
             w-full px-3 py-2.5
             text-sm
             surface-bg
-            border-soft
+            ${passwordError ? "border border-red-400" : "border-soft"}
             rounded-base
             shadow-xs
             input-focus hover-lift
-          "
+          `}
         />
+        {passwordError && (
+          <p className="text-xs text-red-500 mt-1">{passwordError}</p>
+        )}
       </div>
 
       <button


### PR DESCRIPTION
## Description

Currently, the Signup page accepts any password — even a single character — with no validation on either the frontend or backend. This is a security concern.

This PR adds a minimum 6-character password validation on **both frontend and backend**.

Closes #<your-issue-number>

## Changes Made

| File | Changes |
|------|---------|
| `frontend/src/pages/Signup.jsx` | Added real-time password validation + submit guard |
| `backend/controllers/authController.js` | Added server-side password length check |

## What's New

### Frontend — `Signup.jsx`
- **Real-time validation:** As the user types, if the password is less than 6 characters, a red error message appears below the field: *"Password must be at least 6 characters"*
- **Red border:** The password input border turns red when validation fails
- **Submit guard:** Form submission is blocked if password is too short (before any API call)
- **HTML `minLength` attribute:** Added as an extra native browser validation layer

Closes #308 

### Backend — `authController.js`
- **Server-side validation:** Added a check before password hashing:
  ```js
  if (!password || password.length < 6) {
    return res.status(400).json({ message: "Password must be at least 6 characters" });
  }
