### PR TITLE
fix: add validation for unrealistic future task dates

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -11,6 +11,13 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
   const [priority, setPriority] = useState("Low");
   const [dueDate, setDueDate] = useState("");
 
+  const today = new Date();
+  const todayStr = today.getFullYear() + '-' + String(today.getMonth() + 1).padStart(2, '0') + '-' + String(today.getDate()).padStart(2, '0');
+  
+  const maxDateObj = new Date();
+  maxDateObj.setFullYear(today.getFullYear() + 1);
+  const maxDateStr = maxDateObj.getFullYear() + '-' + String(maxDateObj.getMonth() + 1).padStart(2, '0') + '-' + String(maxDateObj.getDate()).padStart(2, '0');
+
   useEffect(() => {
     if (task) {
       /* eslint-disable react-hooks/set-state-in-effect */
@@ -28,6 +35,14 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
     if (!title.trim()) return alert("Title is required");
     if (!priority) return alert("Priority is required");
     if (!dueDate) return alert("Due date is required");
+
+    if (dueDate < todayStr) {
+      return alert("Due date cannot be in the past");
+    }
+    
+    if (dueDate > maxDateStr) {
+      return alert("Due date cannot be more than 1 year in the future");
+    }
 
     onSubmit({
       title: title.trim(),
@@ -158,6 +173,8 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
             <input
               type="date"
               value={dueDate}
+              min={todayStr}
+              max={maxDateStr}
               onChange={(e) => setDueDate(e.target.value)}
               className="w-full mt-1 p-2 border border-soft rounded-lg focus:ring-(--primary) focus:border-(--primary)"
               required


### PR DESCRIPTION
## 📌 Description

Added validation to prevent users from entering unrealistic future task dates such as year `8888` while creating tasks.

## 🔗 Related Issue

Closes #432 

 ## 🛠 Changes Made

- Added frontend validation for task deadlines
- Restricted task dates to within 1 year from the current date
- Prevented unrealistic future date submissions

 ## 📸 Screenshots 
<img width="669" height="349" alt="Screenshot 2026-05-17 at 1 15 48 AM" src="https://github.com/user-attachments/assets/ddeb1e29-626f-4848-a8f4-3de64b510cf7" />


<img width="488" height="232" alt="Screenshot 2026-05-17 at 1 16 11 AM" src="https://github.com/user-attachments/assets/b106056e-d7ca-4723-8589-37ec8649c009" />

 ## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors
* [x] Properly tested changes
* [x] Linked the issue

## 🚀 Notes for Reviewers

Tested the validation flow with both valid and unrealistic future dates to ensure proper task creation behavior.
