### PR TITLE
fix: return created routine data in response

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -77,12 +77,11 @@ export const createRoutine = async (req, res) => {
 
     // save routine in collection
     await newRoutine.save();
-    return res
-      .status(200)
-      .json(
-        { success: true, message: "Routine added successfully" },
-        newRoutine
-      );
+    return res.status(200).json({
+      success: true,
+      message: "Routine added successfully",
+      data: newRoutine,
+    });
   } catch (error) {
     // error handling
     console.log("Error creating routine", error);


### PR DESCRIPTION
## 📌 Description
This PR fixes a bug in `routineController.js` where the `createRoutine` API was incorrectly passing the newly created routine as a second argument to `res.json()`, causing Express to ignore it. The response shape has been updated to correctly return the data inside a single object.

## 🔗 Related Issue
Closes ##441

## 🛠 Changes Made
- Updated the response shape in `backend/controllers/routineController.js` for the `createRoutine` endpoint.
- Ensured the `data` payload returns the `newRoutine` object.
- Adhered strictly to the consistent JSON response format without modifying any other files or variables.

## 📸 Screenshots (if applicable)
N/A - Backend API response fix only.

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
N/A
