### PR TITLE
fix(routine): keep Task Library text readable in dark mode

### DIFF
--- a/frontend/src/components/Routine/TaskLibrary.jsx
+++ b/frontend/src/components/Routine/TaskLibrary.jsx
@@ -22,6 +22,7 @@ function DraggableTask({ task }) {
     opacity: isDragging ? 0 : 1,
     position: "relative",
     zIndex: isDragging ? 99999 : 1,
+    backgroundColor: "color-mix(in srgb, var(--surface) 80%, transparent)",
   };
 
   return (
@@ -30,9 +31,9 @@ function DraggableTask({ task }) {
       style={style}
       {...listeners}
       {...attributes}
-      className="group flex items-center gap-3 rounded-xl border-soft bg-white/80 dark:bg-slate-800/80 p-3
+      className="group flex items-center gap-3 rounded-xl border-soft p-3
                  cursor-grab active:cursor-grabbing
-                 hover:bg-white dark:hover:bg-slate-800 hover:shadow-md transition hover-lift"
+                 hover:shadow-md transition hover-lift"
       role="button"
       tabIndex={0}
       aria-label={`${task.title} - Drag to schedule or use arrow keys`}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -126,7 +126,7 @@ html.dark, html.dark body {
   }
 
   .card-muted {
-    @apply bg-white/80;
+    background-color: color-mix(in srgb, var(--surface) 80%, transparent);
   }
 
   .card-primary {


### PR DESCRIPTION
## Summary
- Task Library panel and draggable task cards now use `var(--surface)` for backgrounds so they follow the `html.dark` theme toggle.
- Fixes invisible task titles when dark mode is enabled via the in-app theme control (light text on a forced white card background).

## Root cause
Theme switching updates CSS variables on `html.dark`, but `card-muted` and task rows used hardcoded `bg-white/80` / `dark:bg-slate-800` classes that did not track the class-based theme.

## Test plan
- [ ] Open Routine Builder → enable dark mode
- [ ] Confirm task names are readable in the Task Library list
- [ ] Toggle back to light mode and confirm styling still looks correct

Fixes #482