### PR TITLE
fix(tasks): purge routine items when bulk deleting tasks

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -1,5 +1,6 @@
 import Task from "../src/models/Task.js";
 import User from "../src/models/User.js";
+import routineModel from "../src/models/Routine.js";
 import { validationResult } from "express-validator";
 
 // Create task function
@@ -196,6 +197,12 @@ export const bulkDeleteTasks = async (req, res) => {
 
     // delete all matching tasks belonging to this user
     await Task.deleteMany({ _id: { $in: ids }, userId: userId });
+
+    // remove orphaned task references from the user's routines
+    await routineModel.updateMany(
+      { userId },
+      { $pull: { items: { taskId: { $in: ids } } } }
+    );
 
     return res
       .status(200)


### PR DESCRIPTION
## Summary
- After `bulkDeleteTasks`, removes matching `items.taskId` entries from the user's routines via MongoDB `$pull`.

## Test plan
- [ ] Create tasks and a routine using them
- [ ] Call bulk-delete for those task IDs
- [ ] Fetch routines — deleted tasks no longer appear in `items`

Fixes #450