### PR TITLE
fix(tasks): remove orphaned routine references after bulk delete

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -1,3 +1,4 @@
+import Routine from "../src/models/Routine.js";
 import Task from "../src/models/Task.js";
 import User from "../src/models/User.js";
 import { validationResult } from "express-validator";
@@ -76,7 +77,7 @@ export const getTasks = async (req, res) => {
       return res
         .status(200)
         .json({ success: true, tasks: [] });
-  }
+    }
     return res.status(200).json({ success: true, tasks });
   } catch (error) {
     // error handling
@@ -188,7 +189,7 @@ export const bulkDeleteTasks = async (req, res) => {
 
     // fetch array of task IDs 
     const { ids } = req.body;
-    if (!ids || ids.length === 0) {
+    if (!Array.isArray(ids) || ids.length === 0) {
       return res
         .status(400)
         .json({ success: false, message: "No task IDs provided" });
@@ -196,6 +197,17 @@ export const bulkDeleteTasks = async (req, res) => {
 
     // delete all matching tasks belonging to this user
     await Task.deleteMany({ _id: { $in: ids }, userId: userId });
+
+    await Routine.updateMany(
+      { userId },
+      {
+        $pull: {
+          items: {
+            taskId: { $in: ids },
+          },
+        },
+      }
+    );
 
     return res
       .status(200)


### PR DESCRIPTION
## 📌 Description

Fixed an issue where bulk deleting tasks left orphaned `taskId` references inside routines.

This PR removes related task references from routine items after tasks are deleted, helping maintain consistency between the Tasks and Routines collections.

Also added validation to ensure `ids` is a valid array before processing bulk deletion requests.

## 🔗 Related Issue

Closes #450

## 🛠 Changes Made

* Added routine cleanup after bulk task deletion
* Removed matching `items.taskId` references using MongoDB `$pull`
* Added validation check using `Array.isArray(ids)`
* Scoped cleanup to routines belonging to the same user

## 📸 Screenshots (if applicable)

N/A (Backend logic change)

## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors related to the implemented change
* [x] Properly tested changes
* [x] Linked the issue

## 🚀 Notes for Reviewers

The cleanup logic was added inside `bulkDeleteTasks` to prevent orphaned task references from remaining inside routine items after deletion.