### PR TITLE
fix(dashboard): prevent blank page when toggling task checkboxes

### DIFF
--- a/frontend/src/components/Dashboard/DashboardTasks.jsx
+++ b/frontend/src/components/Dashboard/DashboardTasks.jsx
@@ -61,13 +61,16 @@ export default function DashboardTasks({ tasks, updateTask }) {
               {/* Checkbox */}
               <input
                 type="checkbox"
-                className="h-4 w-4 accent-(--primary) cursor-pointer"
+                className="h-4 w-4 accent-[var(--primary)] cursor-pointer"
                 checked={task.status === "Completed"}
-                onChange={() =>
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  if (!task?._id) return;
                   updateTask(task._id, {
                     status: task.status === "Completed" ? "Due" : "Completed",
-                  })
-                }
+                  });
+                }}
               />
 
               {/* Task content */}

--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -61,13 +61,16 @@ export default function TaskPreview({ tasks , updateTask}) {
               {/* Checkbox */}
               <input
                 type="checkbox"
-                className="h-4 w-4 accent-(--primary) cursor-pointer"
+                className="h-4 w-4 accent-[var(--primary)] cursor-pointer"
                 checked={task.status === "Completed"}
-                onChange={() =>
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  if (!task?._id) return;
                   updateTask(task._id, {
                     status: task.status === "Completed" ? "Due" : "Completed",
-                  })
-                }
+                  });
+                }}
               />
 
               {/* Content */}

--- a/frontend/src/components/ProtectedRoutes.jsx
+++ b/frontend/src/components/ProtectedRoutes.jsx
@@ -3,18 +3,25 @@ import { AuthContext } from "../context/AuthContext.jsx";
 import { Navigate } from "react-router-dom";
 
 const ProtectedRoutes = ({ children }) => {
+  const { user, token, authReady } = useContext(AuthContext);
 
-  // access token from AuthContext
-  const { token } = useContext(AuthContext);
-
-  // if token doesn't exist, return to login page
   if (!token) {
     return <Navigate to="/login" replace />;
   }
-  // else return the children component
-  else {
-    return children;
+
+  if (!authReady) {
+    return (
+      <div className="text-sm text-muted py-12" role="status" aria-live="polite">
+        Loading your session…
+      </div>
+    );
   }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
 };
 
 export default ProtectedRoutes;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -9,6 +9,7 @@ export const AuthContext = createContext(null);
 const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(() => localStorage.getItem("token"));
+  const [authReady, setAuthReady] = useState(() => !localStorage.getItem("token"));
 
   // logout function
   const logout = () => {
@@ -19,22 +20,29 @@ const AuthProvider = ({ children }) => {
 
   // restore session on app load
   useEffect(() => {
-    if (token) {
-      // fetch logged-in user
-      api
-        .get("/auth/me")
-        .then((res) => {
-          setUser(res.data.user);
-        })
-        .catch(() => {
-          // token invalid or expired
-          logout();
-        });
+    if (!token) {
+      setAuthReady(true);
+      return;
     }
+
+    setAuthReady(false);
+    api
+      .get("/auth/me")
+      .then((res) => {
+        setUser(res.data.user);
+      })
+      .catch(() => {
+        logout();
+      })
+      .finally(() => {
+        setAuthReady(true);
+      });
   }, [token]);
 
   return (
-    <AuthContext.Provider value={{ user, token, setUser, setToken, logout }}>
+    <AuthContext.Provider
+      value={{ user, token, authReady, setUser, setToken, logout }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -22,6 +22,8 @@ const useTasks = () => {
 
   // update task
   const updateTask = async (id, updates) => {
+    if (!id) return;
+
     setTasks((prev) =>
       prev.map((t) => (t._id === id ? { ...t, ...updates } : t))
     );


### PR DESCRIPTION
## Summary
Fixes #476

- Wait for `/auth/me` to finish before rendering protected routes (`authReady` + loading state)
- Redirect to login when token exists but user session is invalid
- Guard `updateTask` when task id is missing
- Stop checkbox click propagation and fix `accent-[var(--primary)]` on dashboard task inputs

## Test plan
- [ ] Log in and open `/dashboard`
- [ ] Toggle checkboxes on Today's Focus and Upcoming Tasks — page stays on dashboard
- [ ] Refresh with valid session — still lands on dashboard
- [ ] Clear/expire token — redirects to login instead of blank main area