### PR TITLE
feat(styles): add missing text-primary utility class

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -81,6 +81,10 @@ html.dark, html.dark body {
     color: var(--text-muted);
   }
 
+  .text-primary {
+    color: var(--primary);
+  }
+
   /* Structural borders */
   .border-soft {
     border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
Fixes #460 (partial — CSS utility only; dependency updates can be a follow-up)

Adds `.text-primary { color: var(--primary); }` to `frontend/src/index.css` so components using `text-primary` (Dashboard, Tasks, About, StatCard) display the theme accent color correctly.

## Test plan
- [ ] Open Dashboard and About — accent links/text use primary color in light and dark mode