### PR TITLE
fix(ui): improve mobile responsiveness on core pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,7 @@ const App = () => {
   return (
     <BrowserRouter>
       <Navbar />
-      <main className="app-bg min-h-screen pt-15 flex justify-center items-center">
+      <main className="app-bg min-h-screen w-full overflow-x-hidden pt-15">
         <Routes>
           <Route path="/" element={<Login />} />
           <Route path="/login" element={<Login />} />

--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -62,8 +62,8 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 animate-in">
-      <div className="bg-(--surface) rounded-2xl shadow-xl w-full max-w-md p-6 relative animate-in delay-100 border border-soft">
+    <div className="fixed inset-0 bg-black/40 flex items-end sm:items-center justify-center z-50 animate-in p-4">
+      <div className="bg-(--surface) rounded-2xl shadow-xl w-full max-w-md max-h-[min(90dvh,100%)] overflow-y-auto p-6 relative animate-in delay-100 border border-soft">
         {/* Close Button */}
         <button
           onClick={onClose}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+html,
+body,
+#root {
+  overflow-x: hidden;
+  max-width: 100%;
+}
+
 :root {
   /* App background (outer layout) */
   --bg: #d0f6e3;

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,6 +1,6 @@
 export default function About() {
   return (
-    <div className="min-h-screen w-full max-w-[1440px] mx-auto px-6 py-10 space-y-12">
+    <div className="min-h-screen w-full max-w-[1440px] mx-auto px-4 sm:px-6 py-8 sm:py-10 space-y-10 sm:space-y-12">
 
       {/* Heading */}
       <div className="text-center max-w-3xl mx-auto">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -95,7 +95,7 @@ export default function Dashboard() {
   }, []);
 
   return (
-    <div className="min-h-screen w-full max-w-[1440px] mx-auto app-bg px-6 py-8 space-y-8 animate-in">
+    <div className="min-h-screen w-full max-w-[1440px] mx-auto app-bg px-4 sm:px-6 py-6 sm:py-8 space-y-6 sm:space-y-8 animate-in">
       {/* Header */}
       <header className="animate-in flex flex-col lg:flex-row justify-between items-start lg:items-center p-6 shadow-md rounded-xl bg-(--surface) gap-4">
         {/* Display time */}
@@ -108,7 +108,7 @@ export default function Dashboard() {
     "{quote}"
   </p>
 
-  <div className="flex justify-between items-center mt-1 w-full">
+  <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mt-1 w-full min-w-0">
     <p className="text-sm text-muted">
       {new Date()
         .toLocaleDateString("en-US", {

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -50,9 +50,10 @@ const Login = () => {
 
   // login component
   return (
+    <div className="w-full flex justify-center px-4 py-8 sm:py-12">
     <form
       className="
-        surface-bg px-10 py-15 rounded-2xl
+        surface-bg px-6 sm:px-10 py-10 sm:py-15 rounded-2xl
         w-full max-w-sm
         flex flex-col gap-6 animate-in
       "
@@ -146,6 +147,7 @@ const Login = () => {
         </Link>
       </p>
     </form>
+    </div>
   );
 };
 

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -152,7 +152,7 @@ export default function RoutineBuilder() {
         handleDragEnd(event);
       }}
     >
-      <div className="app-bg min-h-screen px-6 py-8 animate-in">
+      <div className="app-bg min-h-screen px-4 sm:px-6 py-6 sm:py-8 animate-in w-full max-w-full">
         {/* Header */}
         <header className="mb-8 flex items-start gap-4 animate-in delay-100">
           <button
@@ -267,8 +267,8 @@ export default function RoutineBuilder() {
       </div>
 
       {isSaveModalOpen && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 animate-in">
-          <div className="card card-primary w-full max-w-md animate-in delay-100">
+        <div className="fixed inset-0 bg-black/40 flex items-end sm:items-center justify-center z-50 animate-in p-4">
+          <div className="card card-primary w-full max-w-md max-h-[min(90dvh,100%)] overflow-y-auto animate-in delay-100">
             <h3 className="text-lg font-semibold text-main mb-2">
               Save {selectedDay} Routine
             </h3>

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -77,9 +77,10 @@ const Signup = () => {
 
   // signup component
   return (
+    <div className="w-full flex justify-center px-4 py-8 sm:py-12">
     <form
       className="
-        surface-bg px-10 py-15 rounded-2xl
+        surface-bg px-6 sm:px-10 py-10 sm:py-15 rounded-2xl
         w-full max-w-sm
         flex flex-col gap-6
         animate-in
@@ -220,6 +221,7 @@ const Signup = () => {
         </Link>
       </p>
     </form>
+    </div>
   );
 };
 

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import useTasks from "../hooks/useTasks";
 import TaskItem from "../components/Task/TaskItem";
 import TaskFormModal from "../components/Task/TaskFormModal";
-import { Plus, ArrowLeft, Filter } from "lucide-react";
+import { Plus, ArrowLeft, Filter, Trash2 } from "lucide-react";
 import { CATEGORIES } from "../utils/categoryUtils";
 import EmptyState from "../components/EmptyState";
 
@@ -91,10 +91,10 @@ export default function Tasks() {
   const isOverloaded = highPriorityCount >= 3;
 
   return (
-    <div className="min-h-screen app-bg px-6 lg:px-12 py-8 animate-in">
-      <div className="max-w-[1200px] mx-auto space-y-8">
+    <div className="min-h-screen app-bg px-4 sm:px-6 lg:px-12 py-6 sm:py-8 animate-in w-full">
+      <div className="max-w-[1200px] mx-auto space-y-6 sm:space-y-8 w-full">
         {/* Header */}
-        <div className="flex items-center justify-between gap-6 flex-wrap animate-in delay-100">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 animate-in delay-100">
           <div className="flex items-center gap-4">
             <button
               onClick={() => navigate("/dashboard")}


### PR DESCRIPTION
## Summary
Fixes #481 (initial pass — Dashboard, Tasks, Routine Builder, auth pages, modals)

- Prevent horizontal overflow (`overflow-x-hidden` on root layout and `html/body`)
- Stop vertically centering all routes in `<main>` (was clipping scrollable pages on mobile)
- Responsive horizontal padding on Dashboard, Tasks, Routine Builder, About, Login, Signup
- Stack dashboard date/clock and tasks header actions on narrow screens
- Modals: bottom-aligned on mobile with `max-h` + scroll (`TaskFormModal`, routine save dialog)
- Fix missing `Trash2` import on Tasks bulk-delete button

## Test plan
- [ ] 375px width: Dashboard, Tasks, Routine Builder — no horizontal scroll
- [ ] Open task modal and save-routine modal — content scrolls inside viewport
- [ ] Login/Signup forms centered with side padding
- [ ] Bulk delete selected tasks — icon renders without console error