### PR TITLE
fix: add route-level ErrorBoundaries for /dashboard, /tasks, /routine…

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import NotFound from "./pages/NotFound.jsx";
 import About from "./pages/About.jsx";
 import Profile from './pages/Profile.jsx';
 import ScrollToTop from "./components/ScrollToTop.jsx";
+import ErrorBoundary from "./components/ErrorBoundary.jsx";
 import PageTransition from "./components/PageTransition.jsx";
 
 const AuthLayout = ({ children }) => (
@@ -25,7 +26,7 @@ const AuthLayout = ({ children }) => (
 
 const AnimatedRoutes = () => {
   const location = useLocation();
-  
+
   return (
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
@@ -37,7 +38,9 @@ const AnimatedRoutes = () => {
           path="/dashboard"
           element={
             <ProtectedRoutes>
-              <PageTransition><Dashboard /></PageTransition>
+              <ErrorBoundary>
+                <PageTransition><Dashboard /></PageTransition>
+              </ErrorBoundary>
             </ProtectedRoutes>
           }
         />
@@ -45,7 +48,9 @@ const AnimatedRoutes = () => {
           path="/tasks"
           element={
             <ProtectedRoutes>
-              <PageTransition><Tasks /></PageTransition>
+              <ErrorBoundary>
+                <PageTransition><Tasks /></PageTransition>
+              </ErrorBoundary>
             </ProtectedRoutes>
           }
         />
@@ -53,7 +58,9 @@ const AnimatedRoutes = () => {
           path="/routine-builder"
           element={
             <ProtectedRoutes>
-              <PageTransition><RoutineBuilder /></PageTransition>
+              <ErrorBoundary>
+                <PageTransition><RoutineBuilder /></PageTransition>
+              </ErrorBoundary>
             </ProtectedRoutes>
           }
         />


### PR DESCRIPTION
## 📌 Description
PR #467 implements a root-level ErrorBoundary in `main.jsx` which prevents the entire app from crashing. However, if a single route like `/dashboard` fails, the entire app including Navbar and Footer becomes unusable — users lose navigation entirely.

This PR adds route-level ErrorBoundaries inside `App.jsx` for `/dashboard`, `/tasks`, and `/routine-builder`, so errors are contained to the failing route only, keeping the rest of the app 
fully functional.
## 🔗 Related Issue
Closes #358 

## 🛠 Changes Made
- Imported `ErrorBoundary` component in `App.jsx`
- Wrapped `<Dashboard />`, `<Tasks />`, and `<RoutineBuilder />` 
  individually with `<ErrorBoundary>`
- No new files created — reuses the existing `ErrorBoundary.jsx` 
  from #467

## 📸 Screenshots (if applicable)
Error is shown keeping Navbar and Footer completely usable :-
<img width="1918" height="1026" alt="image" src="https://github.com/user-attachments/assets/6bbf7d87-1b48-429b-8048-541ac92f9c8d" />
<img width="1918" height="1025" alt="image" src="https://github.com/user-attachments/assets/71acf7cb-6351-4838-bba7-bf28928df45a" />

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
This PR builds on #467 — the two boundaries work together as a two-layer error handling system:
- Root-level (`main.jsx`) → catches catastrophic failures
- Route-level (`App.jsx`) → isolates per-page errors, keeps navigation intact

> A Test Error was thrown while capturing the screenshots.
Went ahead with the implementation as discussed in the issue. Happy to adjust if you'd prefer a different approach.
