### PR TITLE
fix(seo): add meta description and Open Graph tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,22 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="description"
+    content="DailyForge — your personal productivity app to manage tasks, routines and daily goals."
+  />
+  <meta property="og:title" content="DailyForge" />
+  <meta
+    property="og:description"
+    content="Manage your daily tasks, routines and goals with DailyForge."
+  />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="DailyForge" />
+  <meta
+    name="twitter:description"
+    content="Manage your daily tasks, routines and goals with DailyForge."
+  />
   <title>DailyForge</title>
 </head>
 


### PR DESCRIPTION
## Summary
Adds `description`, Open Graph, and Twitter card meta tags to `frontend/index.html`.

## Test plan
- [ ] View page source — meta tags present
- [ ] Share link preview (WhatsApp/Slack/Twitter) shows title + description

Fixes #557