### PR TITLE
fix(api): return 200 when user has no routines

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -108,9 +108,6 @@ export const getRoutines = async (req, res) => {
     const routines = await Routine.find({ userId: userId }).sort({
       createdAt: -1,
     });
-    if (routines.length == 0) {
-      return res.status(400).json({ message: "User has no routine", success: false });
-    }
     return res.status(200).json({ success: true, routines });
   } catch (error) {
     // error handling


### PR DESCRIPTION
## Summary
- Removes the `400` early return when `routines.length === 0`
- `GET /api/routines` now always returns `200` with `{ success: true, routines: [] }` for new users

## Test plan
- [ ] New account with no routines → `GET /api/routines` returns 200 and `routines: []`
- [ ] Account with routines → unchanged behavior

Fixes #559