### PR TITLE
fix(ui): clarify 404 redirect button label by auth state

### DIFF
--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -24,11 +24,15 @@ const NotFound = () => {
         </p>
       </div>
 
+      <p className="text-muted text-xs">
+        {token ? "You'll be taken to your dashboard." : "You'll be taken to the login page."}
+      </p>
+
       <button
         onClick={handleGoHome}
         className="btn btn-primary hover-lift cursor-pointer"
       >
-        Go Home
+        {token ? "Go to Dashboard" : "Go to Login"}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Logged-in users see **Go to Dashboard** with a subtitle hint
- Guests see **Go to Login** with matching hint

## Test plan
- [ ] Visit unknown route while logged out → button says Go to Login
- [ ] Visit unknown route while logged in → button says Go to Dashboard

Fixes #533