### PR TITLE
fix(api): return 200 for users with zero tasks

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -70,13 +70,7 @@ export const getTasks = async (req, res) => {
         .json({ success: false, message: "Unauthorized, token invalid" });
     }
 
-    // fetch tasks from database
     const tasks = await Task.find({ userId: userId }).sort({ createdAt: -1 });
-    if (tasks.length == 0) {
-      return res
-        .status(200)
-        .json({ success: true, tasks: [] });
-  }
     return res.status(200).json({ success: true, tasks });
   } catch (error) {
     // error handling


### PR DESCRIPTION
## Summary
- Removes redundant empty-list branch in `getTasks`
- Always returns `{ success: true, tasks }` (empty array for new users)

## Test plan
- [ ] New user with no tasks → `GET /api/tasks` returns 200 and `tasks: []`

Fixes #555