### PR TITLE
fix(auth): prevent login flash on refresh when session is valid

### DIFF
--- a/frontend/src/components/ProtectedRoutes.jsx
+++ b/frontend/src/components/ProtectedRoutes.jsx
@@ -3,18 +3,21 @@ import { AuthContext } from "../context/AuthContext.jsx";
 import { Navigate } from "react-router-dom";
 
 const ProtectedRoutes = ({ children }) => {
+  const { token, isAuthLoading } = useContext(AuthContext);
 
-  // access token from AuthContext
-  const { token } = useContext(AuthContext);
+  if (isAuthLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-sm text-gray-500">Restoring session…</p>
+      </div>
+    );
+  }
 
-  // if token doesn't exist, return to login page
   if (!token) {
     return <Navigate to="/login" replace />;
   }
-  // else return the children component
-  else {
-    return children;
-  }
+
+  return children;
 };
 
 export default ProtectedRoutes;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useCallback, useEffect, useState } from "react";
 import api from "../api/axios";
 
 // create context component
@@ -9,32 +9,57 @@ export const AuthContext = createContext(null);
 const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(() => localStorage.getItem("token"));
+  const [isAuthLoading, setIsAuthLoading] = useState(
+    () => !!localStorage.getItem("token"),
+  );
 
-  // logout function
-  const logout = () => {
+  const logout = useCallback(() => {
     setUser(null);
     setToken(null);
     localStorage.removeItem("token");
-  };
+  }, []);
 
-  // restore session on app load
+  // restore session on app load (wait before treating user as logged out)
   useEffect(() => {
-    if (token) {
-      // fetch logged-in user
-      api
-        .get("/auth/me")
-        .then((res) => {
-          setUser(res.data.user);
-        })
-        .catch(() => {
-          // token invalid or expired
-          logout();
-        });
+    if (!token) {
+      setIsAuthLoading(false);
+      return undefined;
     }
-  }, [token]);
+
+    let cancelled = false;
+    setIsAuthLoading(true);
+
+    api
+      .get("/auth/me")
+      .then((res) => {
+        if (!cancelled) {
+          setUser(res.data.user);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return;
+        }
+        // Only clear session when the token is rejected, not on cold-start/network errors
+        if (err.response?.status === 401) {
+          logout();
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsAuthLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, logout]);
 
   return (
-    <AuthContext.Provider value={{ user, token, setUser, setToken, logout }}>
+    <AuthContext.Provider
+      value={{ user, token, setUser, setToken, logout, isAuthLoading }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 import api from "../api/axios";
@@ -14,8 +14,14 @@ const Login = () => {
   // useNavigate object
   const navigate = useNavigate();
 
-  // useContext for auth
-  const { setUser, setToken } = useContext(AuthContext);
+  const { setUser, setToken, token, user, isAuthLoading } =
+    useContext(AuthContext);
+
+  useEffect(() => {
+    if (!isAuthLoading && token && user) {
+      navigate("/dashboard", { replace: true });
+    }
+  }, [isAuthLoading, token, user, navigate]);
 
   // submit handler
   const handleSubmit = async (e) => {


### PR DESCRIPTION
## Summary
- Adds `isAuthLoading` to `AuthContext` while `/auth/me` restores the user on cold start
- `ProtectedRoutes` shows a short loading state instead of redirecting to `/login` when a token exists
- Only clears the session on **401** (not network/timeout errors during Render cold start)
- `Login` redirects to `/dashboard` when a valid session is already restored

Fixes #552

## Test plan
- [ ] Log in, navigate to `/dashboard`, hard refresh — dashboard stays (no login flash)
- [ ] With valid token, visit `/login` — redirects to dashboard after session restore
- [ ] Expired/invalid token — still redirected to login after `/auth/me` returns 401