### PR TITLE
fix(api): GET /api/routines returns 200 with empty array

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -108,9 +108,6 @@ export const getRoutines = async (req, res) => {
     const routines = await Routine.find({ userId: userId }).sort({
       createdAt: -1,
     });
-    if (routines.length == 0) {
-      return res.status(400).json({ message: "User has no routine", success: false });
-    }
     return res.status(200).json({ success: true, routines });
   } catch (error) {
     // error handling


### PR DESCRIPTION
Fixes #527. Returns routines: [] instead of 400 for new users.