### PR TITLE
fix(ui): routine builder contrast and dashboard CTAs (#507, #504)

### DIFF
--- a/frontend/src/components/Dashboard/DashboardActionLink.jsx
+++ b/frontend/src/components/Dashboard/DashboardActionLink.jsx
@@ -1,0 +1,14 @@
+import { ArrowRight } from "lucide-react";
+
+export default function DashboardActionLink({ children, onClick, className = "" }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 rounded-lg border border-soft bg-white/80 hover:bg-white dark:bg-slate-800/80 dark:hover:bg-slate-700 text-primary focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors cursor-pointer ${className}`}
+    >
+      {children}
+      <ArrowRight size={14} aria-hidden />
+    </button>
+  );
+}

--- a/frontend/src/components/Dashboard/DashboardTasks.jsx
+++ b/frontend/src/components/Dashboard/DashboardTasks.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import DashboardActionLink from "./DashboardActionLink";
 
 export default function DashboardTasks({ tasks, updateTask }) {
   const navigate = useNavigate();
@@ -41,12 +42,9 @@ export default function DashboardTasks({ tasks, updateTask }) {
           <p className="text-xs text-muted">Top priorities for today</p>
         </div>
 
-        <button
-          className="text-sm text-primary hover:underline underline-offset-4 cursor-pointer"
-          onClick={() => navigate("/tasks")}
-        >
-          Manage →
-        </button>
+        <DashboardActionLink onClick={() => navigate("/tasks")}>
+          Manage
+        </DashboardActionLink>
       </div>
 
       {todayTasks?.length ? (

--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import DashboardActionLink from "./DashboardActionLink";
 
 
 export default function TaskPreview({ tasks , updateTask}) {
@@ -119,13 +120,10 @@ export default function TaskPreview({ tasks , updateTask}) {
         </p>
       )}
 
-      <div className="mt-4 text-sm text-primary">
-        <button
-          onClick={() => navigate("/tasks")}
-          className="hover:underline cursor-pointer"
-        >
-          View All Tasks →
-        </button>
+      <div className="mt-4">
+        <DashboardActionLink onClick={() => navigate("/tasks")}>
+          View All Tasks
+        </DashboardActionLink>
       </div>
     </div>
   );

--- a/frontend/src/components/Routine/TaskLibrary.jsx
+++ b/frontend/src/components/Routine/TaskLibrary.jsx
@@ -87,7 +87,7 @@ export default function TaskLibrary({ onAddTask }) {
         placeholder="Search tasks…"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        className="mb-4 rounded-xl border-soft px-3 py-2 text-sm focus:outline-none bg-transparent text-main"
+        className="mb-4 rounded-xl border-soft px-3 py-2 text-sm focus:outline-none bg-white/90 dark:bg-slate-900/60 text-main placeholder:text-muted"
       />
 
       {/* Task List */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -126,7 +126,7 @@ html.dark, html.dark body {
   }
 
   .card-muted {
-    @apply bg-white/80;
+    @apply bg-white/80 dark:bg-slate-800/80;
   }
 
   .card-primary {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,13 +1,14 @@
 import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
-import { CheckCircle2, Calendar, Flame, ArrowRight } from "lucide-react";
+import { CheckCircle2, Calendar } from "lucide-react";
 import LiveClock from "../components/Dashboard/LiveClock";
 
 
 import StatCard from "../components/Dashboard/StatCard";
 import TaskPreview from "../components/Dashboard/TaskPreview";
 import DashboardTasks from "../components/Dashboard/DashboardTasks";
+import DashboardActionLink from "../components/Dashboard/DashboardActionLink";
 import api from "../api/axios.js";
 import useTasks from "../hooks/useTasks.js";
 import { getGreeting } from "../utils/getGreeting";
@@ -164,13 +165,9 @@ export default function Dashboard() {
           {/* Header with button */}
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-lg font-semibold text-main">Saved Routines</h2>
-            <button
-              className="text-sm text-primary hover:underline underline-offset-4 cursor-pointer flex items-center gap-1"
-              onClick={() => navigate("/routine-builder")}
-            >
+            <DashboardActionLink onClick={() => navigate("/routine-builder")}>
               Build
-              <ArrowRight size={16} />
-            </button>
+            </DashboardActionLink>
           </div>
 
           {loadingRoutines ? (


### PR DESCRIPTION
## Summary
- Fix Task Library unreadable text by adding dark-mode surface styles to `card-muted` and search input (#507)
- Replace plain-text dashboard links with `DashboardActionLink` buttons (border, hover, focus ring, icon) (#504)

Closes #507
Closes #504

## Test plan
- [ ] Routine Builder → Task Library readable in light and dark mode
- [ ] Dashboard: Manage / Build / View All Tasks look like buttons and are keyboard-focusable