### PR TITLE
feat(backend): async error handling for auth and routine routes (#528)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,109 +1,76 @@
 import User from "../src/models/User.js";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
+import AppError from "../utils/AppError.js";
 
 // sign up function
 export const signup = async (req, res) => {
-  try {
-    // fetch values from request
-    const { name, email, password } = req.body;
+  const { name, email, password } = req.body;
 
-    if (!name || name.trim().length < 2) {
-      return res.status(400).json({ message: "Name must be at least 2 characters long" });
-    }
-
-    const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
-    if (!password || !passwordRegex.test(password)) {
-      return res.status(400).json({ message: "Password must be at least 8 characters long, include an uppercase letter, a digit, and a special character" });
-    }
-
-    // check user exists or not
-    const checkExisting = await User.findOne({ email });
-    if (checkExisting) {
-      return res.status(409).json({ message: "User already exists" });
-    }
-
-    // hashing the password
-    const hashedPassword = await bcrypt.hash(password, 10);
-
-    // create new user document
-    const newUser = new User({
-      name,
-      email,
-      password: hashedPassword,
-    });
-
-    // save the new user in database
-    await newUser.save();
-
-    // generate token using jwt
-    const token = jwt.sign({ id: newUser._id }, process.env.JWT_SECRET, {
-      expiresIn: "24h",
-    });
-    return res
-      .status(201)
-      .json({ message: "User registered successfully", token });
-  } catch (error) {
-    // error handling
-    console.error("Signup error:", error);
-    return res.status(500).json({ message: "Server error during signup" });
+  if (!name || name.trim().length < 2) {
+    throw new AppError("Name must be at least 2 characters long", 400);
   }
+
+  const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+  if (!password || !passwordRegex.test(password)) {
+    throw new AppError(
+      "Password must be at least 8 characters long, include an uppercase letter, a digit, and a special character",
+      400
+    );
+  }
+
+  const checkExisting = await User.findOne({ email });
+  if (checkExisting) {
+    throw new AppError("User already exists", 409);
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  const newUser = new User({
+    name,
+    email,
+    password: hashedPassword,
+  });
+
+  await newUser.save();
+
+  const token = jwt.sign({ id: newUser._id }, process.env.JWT_SECRET, {
+    expiresIn: "24h",
+  });
+  return res
+    .status(201)
+    .json({ message: "User registered successfully", token });
 };
 
 // login function
 export const login = async (req, res) => {
-  try {
-    // fetch user data from request
-    const { email, password } = req.body;
+  const { email, password } = req.body;
 
-    // check if email and password exist in request
-    if (!email || !password) {
-      return res
-        .status(400)
-        .json({ message: "Email and password are required" });
-    }
-
-    // check if user exists or not
-    const user = await User.findOne({ email });
-    if (!user) {
-      return res.status(409).json({ message: "User does not exist" });
-    }
-
-    // check password using bcrypt
-    const passwordCheck = await bcrypt.compare(password, user.password);
-    if (!passwordCheck) {
-      return res.status(401).json({ message: "Password does not match" });
-    }
-
-    // generate jwt token
-   const token = jwt.sign(
-  { id: user._id },
-  process.env.JWT_SECRET,
-  { expiresIn: process.env.JWT_EXPIRES_IN || "7d" }
-);
-    return res.status(200).json({ message: "Login successful", token });
-  } catch (error) {
-    // error handling
-    console.log("Login error: ", error);
-    return res.status(500).json({ message: "Server error during login" });
+  if (!email || !password) {
+    throw new AppError("Email and password are required", 400);
   }
+
+  const user = await User.findOne({ email });
+  if (!user) {
+    throw new AppError("User does not exist", 409);
+  }
+
+  const passwordCheck = await bcrypt.compare(password, user.password);
+  if (!passwordCheck) {
+    throw new AppError("Password does not match", 401);
+  }
+
+  const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
+    expiresIn: process.env.JWT_EXPIRES_IN || "7d",
+  });
+  return res.status(200).json({ message: "Login successful", token });
 };
 
 // access user details function
 export const getUser = async (req, res) => {
-  try {
-    // fetch user data from request
-    const user = await User.findById(req.userId).select("-password");
-    if (!user) {
-      return res
-        .status(404)
-        .json({ success: false, message: "User not found" });
-    }
-    return res.status(200).json({ success: true, user: user });
-  } catch (_error) {
-    // error handling
-    return res
-      .status(500)
-      .json({ message: "Error fetching user data", success: false });
+  const user = await User.findById(req.userId).select("-password");
+  if (!user) {
+    throw new AppError("User not found", 404);
   }
+  return res.status(200).json({ success: true, user: user });
 };

--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -1,237 +1,135 @@
 import Routine from "../src/models/Routine.js";
 import User from "../src/models/User.js";
+import AppError from "../utils/AppError.js";
 import { checkOverlap } from "../utils/routineUtils.js";
+
+const assertAuthenticatedUser = async (userId) => {
+  const user = await User.findById(userId);
+  if (!user) {
+    throw new AppError("Unauthorized, user not logged in", 401);
+  }
+  return user;
+};
+
+const validateRoutineItems = (items) => {
+  const formatted = [];
+  for (const item of items) {
+    if (!item.duration || item.duration < 10) {
+      throw new AppError(
+        "Each task duration must be at least 10 minutes",
+        400
+      );
+    }
+
+    const endTime = item.startTime + item.duration;
+    formatted.push({
+      day: item.day,
+      startTime: item.startTime,
+      endTime: endTime,
+    });
+  }
+
+  const dayGroups = {};
+  for (const task of formatted) {
+    if (!dayGroups[task.day]) {
+      dayGroups[task.day] = [];
+    }
+    dayGroups[task.day].push(task);
+  }
+
+  for (const day in dayGroups) {
+    const tasks = dayGroups[day];
+    tasks.sort((a, b) => a.startTime - b.startTime);
+    if (checkOverlap(tasks)) {
+      throw new AppError(`Tasks overlap on ${day}`, 400);
+    }
+  }
+};
 
 // Create routine function
 export const createRoutine = async (req, res) => {
-  try {
-    // check if user is logged in or not
-    const userId = req.userId;
-    const user = await User.findById(userId);
-    if (!user) {
-      return res
-        .status(401)
-        .json({ success: false, message: "Unauthorized, user not logged in" });
-    }
+  const userId = req.userId;
+  await assertAuthenticatedUser(userId);
 
-    // fetch routine details from request body
-    const { name, description, items } = req.body;
-    if (!name || items.length == 0 || !items) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Please enter required details" });
-    }
-
-    // calculate endtime for each task
-    const formatted = [];
-    for (const item of items) {
-
-      // check duration greater than 10 mins
-      if (!item.duration || item.duration < 10) {
-        return res.status(400).json({
-          success: false,
-          message: "Each task duration must be at least 10 minutes",
-        });
-      }
-
-      const endTime = item.startTime + item.duration;
-      formatted.push({
-        day: item.day,
-        startTime: item.startTime,
-        endTime: endTime,
-      });
-    }
-
-    // group tasks by day
-    const dayGroups = {};
-    for (const task of formatted) {
-      if (!dayGroups[task.day]) {
-        dayGroups[task.day] = [];
-      }
-      dayGroups[task.day].push(task);
-    }
-
-    // loop through each day
-    for (const day in dayGroups) {
-      const tasks = dayGroups[day];
-
-      // sort tasks by start time
-      tasks.sort((a, b) => a.startTime - b.startTime);
-
-      // compare each task with next task
-      if (checkOverlap(tasks)) {
-        return res.status(400).json({
-          success: false,
-          message: `Tasks overlap on ${day}`,
-        });
-      }
-    }
-
-    // create new routine document
-    const newRoutine = new Routine({
-      userId,
-      name,
-      description,
-      items,
-    });
-
-    // save routine in collection
-    await newRoutine.save();
-    return res
-      .status(200)
-      .json(
-        { success: true, message: "Routine added successfully" },
-        newRoutine
-      );
-  } catch (error) {
-    // error handling
-    console.log("Error creating routine", error);
-    return res
-      .status(500)
-      .json({ success: false, message: "Error creating routine" });
+  const { name, description, items } = req.body;
+  if (!name || !items || items.length === 0) {
+    throw new AppError("Please enter required details", 400);
   }
+
+  validateRoutineItems(items);
+
+  const newRoutine = new Routine({
+    userId,
+    name,
+    description,
+    items,
+  });
+
+  await newRoutine.save();
+  return res.status(201).json({
+    success: true,
+    message: "Routine added successfully",
+    routine: newRoutine,
+  });
 };
 
 // Fetch routine function
 export const getRoutines = async (req, res) => {
-  try {
-    // check if user is logged in or not
-    const userId = req.userId;
-    const user = await User.findById(userId);
-    if (!user) {
-      return res
-        .status(401)
-        .json({ success: false, message: "Unauthorized, user not logged in" });
-    }
+  const userId = req.userId;
+  await assertAuthenticatedUser(userId);
 
-    // fetch routines from database
-    const routines = await Routine.find({ userId: userId }).sort({
-      createdAt: -1,
-    });
-    if (routines.length == 0) {
-      return res.status(400).json({ message: "User has no routine", success: false });
-    }
-    return res.status(200).json({ success: true, routines });
-  } catch (error) {
-    // error handling
-    console.log("Error fetching routine", error);
+  const routines = await Routine.find({ userId: userId }).sort({
+    createdAt: -1,
+  });
+  if (routines.length === 0) {
     return res
-      .status(500)
-      .json({ success: false, message: "Error fetching routine" });
+      .status(400)
+      .json({ message: "User has no routine", success: false });
   }
+  return res.status(200).json({ success: true, routines });
 };
 
 // Update routine function
 export const updateRoutine = async (req, res) => {
-  try {
-    // check if user is logged in or not
-    const userId = req.userId;
-    const user = await User.findById(userId);
-    if (!user) {
-      return res
-        .status(401)
-        .json({ success: false, message: "Unauthorized, user not logged in" });
-    }
+  const userId = req.userId;
+  await assertAuthenticatedUser(userId);
 
-    // fetch updated routine details
-    const updates = req.body;
-    const routineId = req.params.id;
+  const updates = req.body;
+  const routineId = req.params.id;
 
-    if (updates.items) {
-      // calculate endtime for each task
-      const formatted = [];
-      for (const item of updates.items) {
-        const endTime = item.startTime + item.duration;
-        formatted.push({
-          day: item.day,
-          startTime: item.startTime,
-          endTime: endTime,
-        });
-      }
-
-      // group tasks by day
-      const dayGroups = {};
-      for (const task of formatted) {
-        if (!dayGroups[task.day]) {
-          dayGroups[task.day] = [];
-        }
-        dayGroups[task.day].push(task);
-      }
-
-      // loop through each day
-      for (const day in dayGroups) {
-        const tasks = dayGroups[day];
-
-        // sort tasks by start time
-        tasks.sort((a, b) => a.startTime - b.startTime);
-
-        // compare each task with next task
-        if (checkOverlap(tasks)) {
-          return res.status(400).json({
-            success: false,
-            message: `Tasks overlap on ${day}`,
-          });
-        }
-      }
-    }
-
-    // fetch routine from database and update
-    const updatedRoutine = await Routine.findOneAndUpdate(
-      { _id: routineId, userId: userId },
-      { $set: updates },
-      { new: true, runValidators: true }
-    );
-    if (!updatedRoutine) {
-      return res.status(404).json({
-        message: "Routine not found",
-      });
-    }
-    return res.status(200).json({
-      message: "Routine updated successfully",
-      routine: updatedRoutine,
-    });
-  } catch (error) {
-    // error handling
-    console.log("Error updating routine", error);
-    return res
-      .status(500)
-      .json({ success: false, message: "Error updating routine" });
+  if (updates.items) {
+    validateRoutineItems(updates.items);
   }
+
+  const updatedRoutine = await Routine.findOneAndUpdate(
+    { _id: routineId, userId: userId },
+    { $set: updates },
+    { new: true, runValidators: true }
+  );
+  if (!updatedRoutine) {
+    throw new AppError("Routine not found", 404);
+  }
+  return res.status(200).json({
+    message: "Routine updated successfully",
+    routine: updatedRoutine,
+  });
 };
 
 // Delete routine function
 export const deleteRoutine = async (req, res) => {
-  try {
-    // check if user is logged in or not
-    const userId = req.userId;
-    const user = await User.findById(userId);
-    if (!user) {
-      return res
-        .status(401)
-        .json({ success: false, message: "Unauthorized, user not logged in" });
-    }
+  const userId = req.userId;
+  await assertAuthenticatedUser(userId);
 
-    // fetch routine id
-    const routineId = req.params.id;
+  const routineId = req.params.id;
 
-    // fetch routine to be deleted from database
-    const deleteRoutine = await Routine.findOneAndDelete({
-      _id: routineId,
-      userId: userId,
-    });
-    if (!deleteRoutine) {
-      return res.status(404).json({
-        message: "Routine not found",
-      });
-    }
-    return res.status(200).json({
-      message: "Routine deleted successfully",
-    });
-  } catch (error) {
-    // error handling
-    console.log("Error deleting routine", error);
-    return res
-      .status(500)
-      .json({ success: false, message: "Error deleting routine" });
+  const deleted = await Routine.findOneAndDelete({
+    _id: routineId,
+    userId: userId,
+  });
+  if (!deleted) {
+    throw new AppError("Routine not found", 404);
   }
+  return res.status(200).json({
+    message: "Routine deleted successfully",
+  });
 };

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -28,7 +28,7 @@ export const authMiddleware = (req, res, next) => {
 
   } catch (error) {
     // error handling
-    console.log("Token verification error", error);
+    console.error("Token verification error", error);
 
     // expired token
     if (error.name === "TokenExpiredError") {

--- a/backend/middlewares/errorMiddleware.js
+++ b/backend/middlewares/errorMiddleware.js
@@ -1,0 +1,30 @@
+import AppError from "../utils/AppError.js";
+
+/**
+ * Global error handler — consistent JSON for thrown errors and async failures.
+ */
+export const errorHandler = (err, req, res, next) => {
+  const statusCode =
+    err instanceof AppError
+      ? err.statusCode
+      : err.statusCode && Number.isInteger(err.statusCode)
+        ? err.statusCode
+        : 500;
+
+  const message =
+    err instanceof AppError || statusCode < 500
+      ? err.message || "Request failed"
+      : "Internal Server Error";
+
+  if (statusCode >= 500) {
+    console.error("Unhandled error:", err);
+  }
+
+  res.status(statusCode).json({
+    success: false,
+    message,
+    ...(process.env.NODE_ENV === "development" && err.stack
+      ? { stack: err.stack }
+      : {}),
+  });
+};

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,15 +1,16 @@
 import express from "express";
 import { getUser, login, signup } from "../controllers/authController.js";
 import { authMiddleware } from "../middlewares/authMiddleware.js";
+import asyncHandler from "../utils/asyncHandler.js";
 
 // router object for auth
 export const authRouter = express.Router();
 
 // Route for signup
-authRouter.post("/signup", signup);
+authRouter.post("/signup", asyncHandler(signup));
 
 // Route for login
-authRouter.post("/login", login);
+authRouter.post("/login", asyncHandler(login));
 
 // Route for get user (me)
-authRouter.get("/me", authMiddleware, getUser);
+authRouter.get("/me", authMiddleware, asyncHandler(getUser));

--- a/backend/routes/routineRoutes.js
+++ b/backend/routes/routineRoutes.js
@@ -6,18 +6,19 @@ import {
   updateRoutine,
 } from "../controllers/routineController.js";
 import { authMiddleware } from "../middlewares/authMiddleware.js";
+import asyncHandler from "../utils/asyncHandler.js";
 
 // router object for routine
 export const routineRouter = express.Router();
 
 // Route for creating routine
-routineRouter.post("/", authMiddleware, createRoutine);
+routineRouter.post("/", authMiddleware, asyncHandler(createRoutine));
 
 // Route for fetching routines
-routineRouter.get("/", authMiddleware, getRoutines);
+routineRouter.get("/", authMiddleware, asyncHandler(getRoutines));
 
 // Route for updating routine
-routineRouter.put("/:id", authMiddleware, updateRoutine);
+routineRouter.put("/:id", authMiddleware, asyncHandler(updateRoutine));
 
 // Route for deleting routine
-routineRouter.delete("/:id", authMiddleware, deleteRoutine);
+routineRouter.delete("/:id", authMiddleware, asyncHandler(deleteRoutine));

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,7 @@ import connectDB from "../config/db.js";
 import { authRouter } from "../routes/authRoutes.js";
 import { taskRouter } from "../routes/taskRoutes.js";
 import { routineRouter } from "../routes/routineRoutes.js";
+import { errorHandler } from "../middlewares/errorMiddleware.js";
 
 // dotenv config
 dotenv.config();
@@ -43,6 +44,9 @@ app.use("/api/routines", routineRouter);
 app.get("/", (req, res) => {
   res.send("Server running");
 });
+
+// Global error handling (must be registered after routes)
+app.use(errorHandler);
 
 // Start server on port (in .env file)
 app.listen(PORT, () => {

--- a/backend/utils/AppError.js
+++ b/backend/utils/AppError.js
@@ -1,0 +1,12 @@
+/**
+ * Structured application error with HTTP status for the global error handler.
+ */
+export default class AppError extends Error {
+  constructor(message, statusCode = 500) {
+    super(message);
+    this.statusCode = statusCode;
+    this.success = false;
+    this.isOperational = true;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/backend/utils/asyncHandler.js
+++ b/backend/utils/asyncHandler.js
@@ -1,0 +1,8 @@
+/**
+ * Wraps async route handlers and forwards rejections to Express error middleware.
+ */
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+export default asyncHandler;


### PR DESCRIPTION
## Summary
- Extends #528 pattern to auth and routine controllers
- Adds `AppError`, `asyncHandler`, and global `errorHandler` middleware
- Wraps auth/routine routes with `asyncHandler`

Related to #528 (task routes covered in #589)

## Test plan
- [ ] Signup, login, `/auth/me` work as before
- [ ] Routine CRUD returns consistent `{ success: false, message }` on errors
- [ ] Invalid auth returns 401/404 with JSON body