### PR TITLE
chore(backend): log controller errors with console.error (#218)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -84,7 +84,7 @@ export const login = async (req, res) => {
     return res.status(200).json({ message: "Login successful", token });
   } catch (error) {
     // error handling
-    console.log("Login error: ", error);
+    console.error("Login error: ", error);
     return res.status(500).json({ message: "Server error during login" });
   }
 };

--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -85,7 +85,7 @@ export const createRoutine = async (req, res) => {
       );
   } catch (error) {
     // error handling
-    console.log("Error creating routine", error);
+    console.error("Error creating routine", error);
     return res
       .status(500)
       .json({ success: false, message: "Error creating routine" });
@@ -114,7 +114,7 @@ export const getRoutines = async (req, res) => {
     return res.status(200).json({ success: true, routines });
   } catch (error) {
     // error handling
-    console.log("Error fetching routine", error);
+    console.error("Error fetching routine", error);
     return res
       .status(500)
       .json({ success: false, message: "Error fetching routine" });
@@ -192,7 +192,7 @@ export const updateRoutine = async (req, res) => {
     });
   } catch (error) {
     // error handling
-    console.log("Error updating routine", error);
+    console.error("Error updating routine", error);
     return res
       .status(500)
       .json({ success: false, message: "Error updating routine" });
@@ -229,7 +229,7 @@ export const deleteRoutine = async (req, res) => {
     });
   } catch (error) {
     // error handling
-    console.log("Error deleting routine", error);
+    console.error("Error deleting routine", error);
     return res
       .status(500)
       .json({ success: false, message: "Error deleting routine" });

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -51,7 +51,7 @@ export const createTask = async (req, res) => {
       .json({ message: "Task added successfully", newTask });
   } catch (error) {
     // error handling
-    console.log("Error creating task", error);
+    console.error("Error creating task", error);
     return res
       .status(500)
       .json({ success: false, message: "Error creating task" });
@@ -80,7 +80,7 @@ export const getTasks = async (req, res) => {
     return res.status(200).json({ success: true, tasks });
   } catch (error) {
     // error handling
-    console.log("Error fetching tasks", error);
+    console.error("Error fetching tasks", error);
     return res
       .status(500)
       .json({ success: false, message: "Error fetching tasks" });
@@ -130,7 +130,7 @@ export const updateTask = async (req, res) => {
     });
   } catch (error) {
     // error handling
-    console.log("Error updating task", error);
+    console.error("Error updating task", error);
     return res
       .status(500)
       .json({ success: false, message: "Error updating task" });
@@ -167,7 +167,7 @@ export const deleteTask = async (req, res) => {
     });
   } catch (error) {
     // error handling
-    console.log("Error deleting task", error);
+    console.error("Error deleting task", error);
     return res
       .status(500)
       .json({ success: false, message: "Error deleting task" });
@@ -202,7 +202,7 @@ export const bulkDeleteTasks = async (req, res) => {
       .json({ success: true, message: "Tasks deleted successfully" });
   } catch (error) {
     //error handling
-    console.log("Error bulk deleting tasks", error);
+    console.error("Error bulk deleting tasks", error);
     return res
       .status(500)
       .json({ success: false, message: "Error deleting tasks" });

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -28,7 +28,7 @@ export const authMiddleware = (req, res, next) => {
 
   } catch (error) {
     // error handling
-    console.log("Token verification error", error);
+    console.error("Token verification error", error);
 
     // expired token
     if (error.name === "TokenExpiredError") {

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -10,7 +10,7 @@ const useTasks = () => {
       const tasks = await api.get("/tasks");
       setTasks(tasks.data.tasks);
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to load tasks");
+      console.error(error?.response?.data?.message || "Failed to load tasks");
     }
   };
 
@@ -29,7 +29,7 @@ const useTasks = () => {
       await api.put(`/tasks/${id}`, updates);
       await getTasks();
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to update task");
+      console.error(error?.response?.data?.message || "Failed to update task");
       await getTasks();
     }
   };


### PR DESCRIPTION
## Summary
- Replace `console.log` with `console.error` in task, routine, and auth controllers
- Same for auth middleware token verification failures
- Update `useTasks` hook to log load/update failures with `console.error`

## Test plan
- [ ] Trigger a failed login or invalid token — server stderr shows error without `console.log` noise
- [ ] Task CRUD still works

Relates to #218