### PR TITLE
fix(ui): hide native password reveal icons (#339)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -174,4 +174,14 @@ html.dark, html.dark body {
       transform: translateY(0);
     }
   }
+
+  /* Hide native password reveal controls (overlap custom Eye toggle) */
+  input[type="password"]::-ms-reveal {
+    display: none;
+  }
+
+  input[type="password"]::-webkit-credentials-auto-fill-button {
+    visibility: hidden;
+    pointer-events: none;
+  }
 }


### PR DESCRIPTION
## Summary
Hide `::-ms-reveal` and WebKit credential buttons so they do not overlap the custom Eye toggle.

Closes #339