### PR TITLE
fix(auth): prevent protected route flash (#237)

### DIFF
--- a/frontend/src/components/ProtectedRoutes.jsx
+++ b/frontend/src/components/ProtectedRoutes.jsx
@@ -3,18 +3,17 @@ import { AuthContext } from "../context/AuthContext.jsx";
 import { Navigate } from "react-router-dom";
 
 const ProtectedRoutes = ({ children }) => {
+  const { token, initializing } = useContext(AuthContext);
 
-  // access token from AuthContext
-  const { token } = useContext(AuthContext);
+  if (initializing) {
+    return null;
+  }
 
-  // if token doesn't exist, return to login page
   if (!token) {
     return <Navigate to="/login" replace />;
   }
-  // else return the children component
-  else {
-    return children;
-  }
+
+  return children;
 };
 
 export default ProtectedRoutes;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -9,32 +9,49 @@ export const AuthContext = createContext(null);
 const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(() => localStorage.getItem("token"));
+  const [initializing, setInitializing] = useState(
+    () => !!localStorage.getItem("token")
+  );
 
   // logout function
   const logout = () => {
     setUser(null);
     setToken(null);
     localStorage.removeItem("token");
+    setInitializing(false);
   };
 
   // restore session on app load
   useEffect(() => {
-    if (token) {
-      // fetch logged-in user
-      api
-        .get("/auth/me")
-        .then((res) => {
-          setUser(res.data.user);
-        })
-        .catch(() => {
-          // token invalid or expired
-          logout();
-        });
+    if (!token) {
+      setInitializing(false);
+      return;
     }
+
+    let cancelled = false;
+    setInitializing(true);
+
+    api
+      .get("/auth/me")
+      .then((res) => {
+        if (!cancelled) setUser(res.data.user);
+      })
+      .catch(() => {
+        if (!cancelled) logout();
+      })
+      .finally(() => {
+        if (!cancelled) setInitializing(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [token]);
 
   return (
-    <AuthContext.Provider value={{ user, token, setUser, setToken, logout }}>
+    <AuthContext.Provider
+      value={{ user, token, setUser, setToken, logout, initializing }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,6 +11,7 @@ const Login = () => {
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   // useNavigate object
   const navigate = useNavigate();
 
@@ -21,8 +22,9 @@ const Login = () => {
   const handleSubmit = async (e) => {
     // prevents page from refreshing
     e.preventDefault();
+    setIsLoading(true);
+    setError("");
 
-    // send request to server
     try {
       const res = await api.post("/auth/login", {
         email,
@@ -41,10 +43,9 @@ const Login = () => {
       // redirect to dashboard
       navigate("/dashboard");
     } catch (error) {
-      // handle error
-      console.log("Login failed");
-      console.log(error.response?.data || error.message);
       setError(error.response?.data?.message || "Invalid email or password.");
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -131,9 +132,10 @@ const Login = () => {
       )}
       <button
         type="submit"
-        className="btn btn-primary cursor-pointer w-full mt-2 hover-lift"
+        disabled={isLoading}
+        className="btn btn-primary cursor-pointer w-full mt-2 hover-lift disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        Login
+        {isLoading ? "Logging in..." : "Login"}
       </button>
 
       <p className="text-center text-sm text-muted">


### PR DESCRIPTION
## Summary
- Add `initializing` state while `/auth/me` restores the session
- `ProtectedRoutes` renders nothing until auth check completes
- Login form shows loading text and disables submit while pending

Closes #237