### PR TITLE
fix(routines): Task Library updates after Create Task (#611)

### DIFF
--- a/frontend/src/components/Routine/TaskLibrary.jsx
+++ b/frontend/src/components/Routine/TaskLibrary.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useDraggable } from "@dnd-kit/core";
-import useTasks from "../../hooks/useTasks.js";
 import EmptyState from "../EmptyState";
 
 /* ---------------- Draggable Task Item ---------------- */
@@ -59,9 +58,7 @@ function DraggableTask({ task }) {
 }
 
 /* ---------------- Task Library ---------------- */
-export default function TaskLibrary({ onAddTask }) {
-  const { tasks } = useTasks();
-
+export default function TaskLibrary({ tasks = [], onAddTask }) {
   const [query, setQuery] = useState("");
 
   const filteredTasks = tasks?.filter((task) =>

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -173,7 +173,7 @@ export default function RoutineBuilder() {
         {/* Main Layout */}
         <div className="grid grid-cols-12 gap-6 animate-in delay-200">
           <aside className="col-span-12 md:col-span-3">
-            <TaskLibrary onAddTask={() => setIsModalOpen(true)} />
+            <TaskLibrary tasks={tasks} onAddTask={() => setIsModalOpen(true)} />
           </aside>
 
           <section className="col-span-12 md:col-span-9">


### PR DESCRIPTION
## Summary
- `TaskLibrary` now receives `tasks` from `RoutineBuilder` instead of calling `useTasks()` again.
- Fixes duplicate hook state where newly created tasks did not appear in the library until a full page refresh.

Fixes #611

## Test plan
- [ ] Open Routine Builder → Add Task → Create Task
- [ ] New task appears immediately in Task Library sidebar