### PR TITLE
fix(ui): TaskPreview typo and link hover styles (#608)

### DIFF
--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -99,7 +99,7 @@ export default function TaskPreview({ tasks , updateTask}) {
                     </span>
                   )}
 
-                  {/*Disply Remaining Time */}
+                  {/* Display remaining time */}
                   {task.dueDate && (
                     <span className="text-[11px] text-red-500 font-medium">
                       {remainingTime > 0
@@ -119,10 +119,11 @@ export default function TaskPreview({ tasks , updateTask}) {
         </p>
       )}
 
-      <div className="mt-4 text-sm text-primary">
+      <div className="mt-4 text-sm">
         <button
+          type="button"
           onClick={() => navigate("/tasks")}
-          className="hover:underline cursor-pointer"
+          className="text-primary hover:underline underline-offset-4 cursor-pointer"
         >
           View All Tasks →
         </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -81,6 +81,10 @@ html.dark, html.dark body {
     color: var(--text-muted);
   }
 
+  .text-primary {
+    color: var(--primary);
+  }
+
   /* Structural borders */
   .border-soft {
     border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Add `.text-primary` utility to `index.css`
- Fix "Disply" comment typo in TaskPreview
- Align "View All Tasks" link hover with dashboard pattern

Fixes #608

## Test plan
- [ ] Dashboard TaskPreview link uses primary color and underline on hover