### PR TITLE
fix(signup): remove duplicate password field

### DIFF
--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -145,26 +145,6 @@ const Signup = () => {
         <label htmlFor="password" className="text-sm font-medium text-main">
           Password
         </label>
-        <input
-          type="password"
-          id="password"
-          value={password}
-          onChange={(e) => {
-            setPassword(e.target.value);
-          }}
-          placeholder="••••••••"
-          required
-          className={`
-            w-full px-3 py-2.5
-            text-sm
-            surface-bg
-            rounded-base
-            shadow-xs
-            input-focus hover-lift
-            ${errors.password ? "border-red-500" : "border-soft"}
-          `}
-        />
-        {errors.password && <span className="text-red-500 text-xs">{errors.password}</span>}
         <div className="relative">
           <input
             type={showPassword ? "text" : "password"}
@@ -175,15 +155,15 @@ const Signup = () => {
             }}
             placeholder="••••••••"
             required
-            className="
+            className={`
               w-full px-3 py-2.5 pr-10
               text-sm
               surface-bg
-              border-soft
               rounded-base
               shadow-xs
               input-focus hover-lift
-            "
+              ${errors.password ? "border-red-500" : "border-soft"}
+            `}
           />
           <button
             type="button"
@@ -194,6 +174,7 @@ const Signup = () => {
             {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
           </button>
         </div>
+        {errors.password && <span className="text-red-500 text-xs">{errors.password}</span>}
       </div>
 
       {error && (


### PR DESCRIPTION
## Summary
- Removes the redundant plain password input on the signup form
- Keeps the show/hide toggle field and moves validation errors below it

Fixes #619

## Test plan
- [ ] Open `/signup` and confirm only one password field renders
- [ ] Toggle show/hide password works
- [ ] Password validation errors display under the field