### PR TITLE
fix(auth): align password visibility toggle icons

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -120,7 +120,7 @@ const Login = () => {
             className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-main transition-colors cursor-pointer flex items-center justify-center"
             aria-label={showPassword ? "Hide password" : "Show password"}
           >
-            {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            {showPassword ? <Eye size={18} /> : <EyeOff size={18} />}
           </button>
         </div>
       </div>

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -191,7 +191,7 @@ const Signup = () => {
             className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-main transition-colors cursor-pointer flex items-center justify-center"
             aria-label={showPassword ? "Hide password" : "Show password"}
           >
-            {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            {showPassword ? <Eye size={18} /> : <EyeOff size={18} />}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Swap Eye/EyeOff icons on Login and Signup so the icon matches visibility state
- Open eye when password is visible; slashed eye when hidden

Fixes #622

## Test plan
- [ ] Toggle password on Login — icon switches between Eye and EyeOff correctly
- [ ] Same on Signup after #619 duplicate field fix