### PR TITLE
fix(routines): return 200 with empty array when user has no routines

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -108,9 +108,6 @@ export const getRoutines = async (req, res) => {
     const routines = await Routine.find({ userId: userId }).sort({
       createdAt: -1,
     });
-    if (routines.length == 0) {
-      return res.status(400).json({ message: "User has no routine", success: false });
-    }
     return res.status(200).json({ success: true, routines });
   } catch (error) {
     // error handling


### PR DESCRIPTION
## Summary
- Return HTTP 200 with `routines: []` when the user has no saved routines yet
- Removes incorrect 400 that caused the frontend to treat empty state as an error

Fixes #628

## Test plan
- [ ] New user with no routines gets 200 and empty array
- [ ] After saving a routine, routines appear in Routine Builder and Dashboard