### PR TITLE
fix(dashboard): use theme surface tokens for task and routine cards

### DIFF
--- a/frontend/src/components/Dashboard/DashboardTasks.jsx
+++ b/frontend/src/components/Dashboard/DashboardTasks.jsx
@@ -1,5 +1,7 @@
 import { useNavigate } from "react-router-dom";
 
+import EmptyState from "../EmptyState";
+
 export default function DashboardTasks({ tasks, updateTask }) {
   const navigate = useNavigate();
 
@@ -56,7 +58,7 @@ export default function DashboardTasks({ tasks, updateTask }) {
               key={task._id}
               className={`group relative flex items-center gap-4 border-l-4 rounded-xl p-4 transition-all duration-200
               ${priorityBorder[task.priority]}
-              bg-white/80 hover:bg-white dark:bg-slate-800/80 dark:hover:bg-slate-800 shadow-sm hover:shadow-md`}
+              surface-bg hover:shadow-md border border-soft shadow-sm`}
             >
               {/* Checkbox */}
               <input
@@ -105,15 +107,7 @@ export default function DashboardTasks({ tasks, updateTask }) {
           ))}
         </div>
       ) : (
-        <div className="text-sm text-muted text-center py-6">
-          No tasks for today.
-          <span
-            className="block mt-2 text-primary hover:underline cursor-pointer"
-            onClick={() => navigate("/tasks")}
-          >
-            Add your first task →
-          </span>
-        </div>
+        <EmptyState type="today" onAction={() => navigate("/tasks")} />
       )}
     </div>
   );

--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -56,7 +56,7 @@ export default function TaskPreview({ tasks , updateTask}) {
               key={task._id}
               className={`flex items-center gap-4 border-l-4 rounded-xl p-4 transition
               ${priorityBorder[task.priority]}
-              bg-white/80 hover:bg-white dark:bg-slate-800/80 dark:hover:bg-slate-800 shadow-sm`}
+              surface-bg border border-soft shadow-sm hover:shadow-md`}
             >
               {/* Checkbox */}
               <input

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -184,7 +184,7 @@ export default function Dashboard() {
               {savedRoutines.map((routine) => (
                 <li
                   key={routine._id}
-                  className="border-l-4 border-primary rounded-xl p-4 bg-white/80 hover:bg-white dark:bg-slate-800/80 dark:hover:bg-slate-800 shadow-sm hover:shadow-md transition-all duration-200 animate-in"
+                  className="border-l-4 border-primary rounded-xl p-4 surface-bg border border-soft shadow-sm hover:shadow-md transition-all duration-200 animate-in"
                 >
                   <p className="font-medium text-main">{routine.name}</p>
                   {routine.description && (


### PR DESCRIPTION
## Summary
- Use `surface-bg` and `border-soft` on Dashboard task cards, upcoming tasks, and saved routines
- Improves light-mode contrast and keeps dark mode consistent with design tokens

Fixes #629

## Test plan
- [ ] Toggle light mode on Dashboard — task blocks use light surface, not dense purple
- [ ] Dark mode task cards still readable