### PR TITLE
fix: prevent direct state mutation of tasks array

### DIFF
--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -98,7 +98,7 @@ export default function Tasks() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-4 animate-in delay-200">
             {tasks.length ? (
-              tasks
+              [...tasks]
                 .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
                 .map((task) => (
                   <TaskItem


### PR DESCRIPTION
## 📌 Description
This PR addresses a bug where the `tasks` state array returned by `useTasks()` hook was being mutated directly in `Tasks.jsx` using `tasks.sort()`. Since React state should be treated as immutable, sorting is now performed on a shallow copy of the state array (`[...tasks].sort()`).

## 🔗 Related Issue
Closes #494 

## 🛠 Changes Made
- Modified `frontend/src/pages/Tasks.jsx` to create a shallow copy of the `tasks` array prior to calling `.sort()`.

## 📸 Screenshots (if applicable)
N/A (Under-the-hood rendering logic/stability improvement)

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
N/A
