### PR TITLE
fix(signup): separate confirm password field (#615)

### DIFF
--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -5,58 +5,45 @@ import api from "../api/axios";
 import { AuthContext } from "../context/AuthContext.jsx";
 
 const Signup = () => {
-  // three states for inputs
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
-  // useNavigate object
   const navigate = useNavigate();
-
-  // useContext for auth
   const { setUser, setToken } = useContext(AuthContext);
 
-  // submit handler
   const handleSubmit = async (e) => {
-    // prevents page from refreshing
     e.preventDefault();
 
     if (!validate()) return;
-    // set loading state
     setIsLoading(true);
     setError("");
 
-    // send request to server
     try {
       const res = await api.post("/auth/signup", {
         name,
         email,
         password,
       });
-      console.log("Signup success: ", res.data);
 
-      // save token in localstorage for later api calls
       localStorage.setItem("token", res.data.token);
       setToken(res.data.token);
 
-      // get user details
       const me = await api.get("/auth/me");
       setUser(me.data.user);
 
-      // redirect to dashboard
       navigate("/dashboard");
-    } catch (error) {
-      // handle error
-      console.log("Signup failed");
-      const errorMessage = error.response?.data?.message || error.message || "Signup failed. Please try again.";
+    } catch (err) {
+      const errorMessage =
+        err.response?.data?.message || err.message || "Signup failed. Please try again.";
       setError(errorMessage);
-      console.log(errorMessage);
     } finally {
-      // reset loading state
       setIsLoading(false);
     }
   };
@@ -70,12 +57,14 @@ const Signup = () => {
     if (!passwordRegex.test(password)) {
       newErrors.password = "Password: min 8 chars, 1 uppercase, 1 digit, 1 special character";
     }
+    if (password !== confirmPassword) {
+      newErrors.confirmPassword = "Passwords do not match";
+    }
 
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
-  // signup component
   return (
     <form
       className="
@@ -98,9 +87,7 @@ const Signup = () => {
           type="text"
           id="name"
           value={name}
-          onChange={(e) => {
-            setName(e.target.value);
-          }}
+          onChange={(e) => setName(e.target.value)}
           placeholder="Full Name"
           required
           className={`
@@ -124,9 +111,7 @@ const Signup = () => {
           type="email"
           id="email"
           value={email}
-          onChange={(e) => {
-            setEmail(e.target.value);
-          }}
+          onChange={(e) => setEmail(e.target.value)}
           placeholder="user@email.com"
           required
           className="
@@ -145,45 +130,24 @@ const Signup = () => {
         <label htmlFor="password" className="text-sm font-medium text-main">
           Password
         </label>
-        <input
-          type="password"
-          id="password"
-          value={password}
-          onChange={(e) => {
-            setPassword(e.target.value);
-          }}
-          placeholder="••••••••"
-          required
-          className={`
-            w-full px-3 py-2.5
-            text-sm
-            surface-bg
-            rounded-base
-            shadow-xs
-            input-focus hover-lift
-            ${errors.password ? "border-red-500" : "border-soft"}
-          `}
-        />
-        {errors.password && <span className="text-red-500 text-xs">{errors.password}</span>}
         <div className="relative">
           <input
             type={showPassword ? "text" : "password"}
             id="password"
             value={password}
-            onChange={(e) => {
-              setPassword(e.target.value);
-            }}
+            onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
             required
-            className="
+            autoComplete="new-password"
+            className={`
               w-full px-3 py-2.5 pr-10
               text-sm
               surface-bg
-              border-soft
               rounded-base
               shadow-xs
               input-focus hover-lift
-            "
+              ${errors.password ? "border-red-500" : "border-soft"}
+            `}
           />
           <button
             type="button"
@@ -194,6 +158,45 @@ const Signup = () => {
             {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
           </button>
         </div>
+        {errors.password && <span className="text-red-500 text-xs">{errors.password}</span>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="confirmPassword" className="text-sm font-medium text-main">
+          Confirm password
+        </label>
+        <div className="relative">
+          <input
+            type={showConfirmPassword ? "text" : "password"}
+            id="confirmPassword"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="••••••••"
+            required
+            autoComplete="new-password"
+            className={`
+              w-full px-3 py-2.5 pr-10
+              text-sm
+              surface-bg
+              border-soft
+              rounded-base
+              shadow-xs
+              input-focus hover-lift
+              ${errors.confirmPassword ? "border-red-500" : "border-soft"}
+            `}
+          />
+          <button
+            type="button"
+            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-main transition-colors cursor-pointer flex items-center justify-center"
+            aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+          >
+            {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+          </button>
+        </div>
+        {errors.confirmPassword && (
+          <span className="text-red-500 text-xs">{errors.confirmPassword}</span>
+        )}
       </div>
 
       {error && (


### PR DESCRIPTION
## Summary
- Removes duplicate password input that shared the same React state
- Adds independent **Confirm password** field with visibility toggle
- Validates passwords match before submitting signup

## Test plan
- [ ] Open `/signup` and type different values in password vs confirm — submit blocked with error
- [ ] Matching passwords allow signup to proceed
- [ ] Eye toggles work on both fields independently

Closes #615