### PR TITLE
fix: nextTask now respects active category filters in Tasks page

### DIFF
--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -81,7 +81,7 @@ export default function Tasks() {
     return due >= now && due <= threeDaysFromNow;
   });
 //changed logic
-  const nextTask = tasks
+  const nextTask = filteredTasks
   .filter((task) => task.dueDate && task.status !== "Completed")
   .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))[0];
 


### PR DESCRIPTION
## 📌 Description
Fixed an inconsistency in the Tasks page where the `nextTask` sidebar 
fallback was being computed from the raw `tasks` array, completely 
ignoring any active category filters applied by the user. Changed 
`tasks` to `filteredTasks` so the sidebar stays in sync with the 
filtered task list.

## 🔗 Related Issue
Closes #578 

## 🛠 Changes Made
- Changed `tasks` to `filteredTasks` in `nextTask` computation (line 84, `Tasks.jsx`)
- `nextTask` now respects active category filters, consistent with 
  all other insight widgets on the same page (`upcomingDeadlines`, 
  `highPriorityCount`, `completedTasks`)

## 📸 Screenshots (if applicable)
N/A — Logic fix, no UI layout changes.

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Only one line changed in `frontend/src/pages/Tasks.jsx` (line 84).
`filteredTasks` is already defined above this line and equals `tasks` 
when no filter is active — so default behavior is completely unchanged. 
The fix only affects cases where a category filter is applied.
