### PR TITLE
fix: conditionally apply min date constraint only on task creation no…

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -36,8 +36,8 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
     if (!priority) return alert("Priority is required");
     if (!dueDate) return alert("Due date is required");
 
-    if (dueDate < todayStr) {
-      return alert("Due date cannot be in the past");
+    if (!task && dueDate < todayStr) {
+       return alert("Due date cannot be in the past");
     }
     
     if (dueDate > maxDateStr) {
@@ -173,7 +173,7 @@ export default function TaskFormModal({ task, onClose, onSubmit }) {
             <input
               type="date"
               value={dueDate}
-              min={todayStr}
+              min={task ? undefined : todayStr}
               max={maxDateStr}
               onChange={(e) => setDueDate(e.target.value)}
               onClick={(e) => e.target.showPicker?.()}


### PR DESCRIPTION
## 📌 Description
Fixed a bug where editing an existing task with a past due date was 
blocked by the date picker's `min` constraint. Previously, `min={todayStr}` 
was applied unconditionally, making it impossible to update any other 
field (title, priority, etc.) without also changing the due date.

## 🔗 Related Issue
Closes #558

## 🛠 Changes Made
- In `TaskFormModal.jsx`, changed `min={todayStr}` to `min={task ? undefined : todayStr}` 
  so the minimum date constraint only applies when creating a new task
- Updated `handleSubmit` validation to `if (!task && dueDate < todayStr)` 
  so past due date check only runs in create mode, not edit mode

## 📸 Screenshots (if applicable)
N/A — Logic fix, no UI layout changes.

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Two changes made in `frontend/src/components/Task/TaskFormModal.jsx` only.
When `task` prop exists (edit mode) — min constraint is removed and 
past date validation is skipped.
When `task` prop is null (create mode) — original behavior is completely 
unchanged. No other files were modified.
