### PR TITLE
Improve mobile responsiveness of weekly schedule

### DIFF
--- a/frontend/src/components/Routine/WeeklyGrid.jsx
+++ b/frontend/src/components/Routine/WeeklyGrid.jsx
@@ -77,7 +77,7 @@ function DroppableCell({ day, time, tasks , onDeleteTask}) {
 /* ---------------- Weekly Grid ---------------- */
 export default function WeeklyGrid({ scheduledTasks, onSaveDay , onDeleteTask }) {
   return (
-    <div className="card card-primary !pl-2 !pr-2.5 !py-3 animate-in">
+    <div className="card card-primary !pl-2.5 !pr-2.5 !py-3 animate-in">
       <h2 className="text-lg font-semibold text-main mb-4 px-6.5 pt-3">Weekly Schedule</h2>
 
       <div
@@ -119,7 +119,7 @@ export default function WeeklyGrid({ scheduledTasks, onSaveDay , onDeleteTask })
         {TIME_SLOTS.map((time) => (
           <div key={time} className="contents">
             {/* Time label */}
-            <div className="text-[9px] sm:text-xs text-muted pr-[2px] pt-2 text-right">
+            <div className="flex items-start justify-end pt-2 pr-2 text-[9px] sm:text-xs text-muted">
               {time}
             </div>
 

--- a/frontend/src/components/Routine/WeeklyGrid.jsx
+++ b/frontend/src/components/Routine/WeeklyGrid.jsx
@@ -77,13 +77,13 @@ function DroppableCell({ day, time, tasks , onDeleteTask}) {
 /* ---------------- Weekly Grid ---------------- */
 export default function WeeklyGrid({ scheduledTasks, onSaveDay , onDeleteTask }) {
   return (
-    <div className="card card-primary overflow-x-auto animate-in">
-      <h2 className="text-lg font-semibold text-main mb-4">Weekly Schedule</h2>
+    <div className="card card-primary !pl-2 !pr-2.5 !py-3 animate-in">
+      <h2 className="text-lg font-semibold text-main mb-4 px-6.5 pt-3">Weekly Schedule</h2>
 
       <div
-        className="grid"
+      className="grid w-full"
         style={{
-          gridTemplateColumns: "80px repeat(7, minmax(120px, 1fr))",
+          gridTemplateColumns: "34px repeat(7, minmax(0, 1fr))",
         }}
       >
         {/* ===== Save Buttons Row ===== */}
@@ -92,7 +92,7 @@ export default function WeeklyGrid({ scheduledTasks, onSaveDay , onDeleteTask })
           <div key={`save-${day}`} className="flex justify-center pb-2">
             <button
               onClick={() => onSaveDay(day)}
-              className="btn btn-primary px-3 py-1 text-xs cursor-pointer hover-lift"
+              className="btn btn-primary !px-2.25 !py-1.5 text-[9px] sm:text-xs cursor-pointer hover-lift"
             >
               Save
             </button>
@@ -103,23 +103,33 @@ export default function WeeklyGrid({ scheduledTasks, onSaveDay , onDeleteTask })
         {DAYS.map((day) => (
           <div
             key={day}
-            className="text-sm font-medium text-main text-center pb-2"
+                        className="text-sm font-medium text-main text-center pb-2"
           >
+            {/* Mobile short names */}
+          <span className="sm:hidden">
+            {day.slice(0, 3)}
+          </span>
+          {/* Desktop full names */}
+          <span className="hidden sm:inline">
             {day}
+          </span>
           </div>
         ))}
         {/* ===== Time Rows ===== */}
         {TIME_SLOTS.map((time) => (
           <div key={time} className="contents">
             {/* Time label */}
-            <div className="text-xs text-muted pr-2 pt-3 text-right">
+            <div className="text-[9px] sm:text-xs text-muted pr-[2px] pt-2 text-right">
               {time}
             </div>
 
             {/* Cells */}
             {DAYS.map((day) => (
+                <div
+              key={`${day}-${time}`}
+              className="min-w-0"
+            >
               <DroppableCell
-                key={`${day}-${time}`}
                 day={day}
                 time={time}
                 tasks={scheduledTasks.filter(
@@ -127,10 +137,11 @@ export default function WeeklyGrid({ scheduledTasks, onSaveDay , onDeleteTask })
                 )}
                 onDeleteTask={onDeleteTask}
               />
+              </div>
             ))}
           </div>
         ))}
       </div>
     </div>
-  );
+);
 }


### PR DESCRIPTION
## 📌 Description

Improved the mobile responsiveness of the Weekly Schedule section in the Routine Builder.

This update reduces excessive horizontal scrolling on smaller screens and adjusts the grid layout, spacing, and sizing to make the schedule more usable on compact mobile devices while preserving the desktop layout.

## 🔗 Related Issue

Closes #468

## ✨ Changes Made

* Reduced excessive horizontal overflow on smaller screens
* Optimized spacing and sizing for columns
* Improved visibility and usability of the schedule layout on compact devices
* Adjusted grid sizing and spacing while preserving the existing desktop structure

## 📷 Screenshots

<img width="444" height="758" alt="image" src="https://github.com/user-attachments/assets/32df00b5-e32f-43ef-aec7-a218e45ce8ee" />

<img width="1884" height="814" alt="image" src="https://github.com/user-attachments/assets/028fd00b-ef4b-4716-a518-29478a6c8161" />


## ✅ Checklist

* [x] Code runs locally
* [x] No console errors
* [x] Linked the issue
* [x] Tested responsiveness on smaller screens

## 📝 Notes for Reviewers

I stopped at this stage since the core mobile overflow issue is resolved and the layout is now usable on smaller screens.

One thing I noticed is that the per-day “Save” buttons still feel slightly crowded on very small screens. I wasn’t sure whether you’d prefer:

* keeping the current layout,
* redesigning the mobile interaction,
* or switching to a single selected-day view.

Also, I noticed that tasks currently cannot be dragged from the Task Library into the Weekly Schedule in my local setup. Is this already being worked on, or should I open a separate PR/issue for it?