### PR TITLE
fix(routine): restore latest saved routine in Weekly Grid after page refresh (#655)

### DIFF
--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -21,6 +21,27 @@ export default function RoutineBuilder() {
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [scheduledTasks, setScheduledTasks] = useState([]);
+
+  // Create a lookup map for task titles by taskId to enable O(1) rendering lookups
+  const taskMap = useMemo(() => {
+    const map = {};
+    if (Array.isArray(tasks)) {
+      tasks.forEach((t) => {
+        if (t && t._id) {
+          map[t._id] = t.title;
+        }
+      });
+    }
+    return map;
+  }, [tasks]);
+
+  // Map local scheduled tasks to dynamically resolve task titles, avoiding race conditions
+  const gridTasks = useMemo(() => {
+    return scheduledTasks.map((task) => ({
+      ...task,
+      title: taskMap[task.taskId] || (tasks.length === 0 ? "Loading Task..." : "Unknown Task"),
+    }));
+  }, [scheduledTasks, taskMap, tasks]);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [selectedDay, setSelectedDay] = useState(null);
   const [routineName, setRoutineName] = useState("");
@@ -53,10 +74,22 @@ export default function RoutineBuilder() {
     try {
       setLoadingRoutines(true);
       const res = await api.get("/routines");
-      // res.data.routines is the array you need
-      setSavedRoutines(
-        Array.isArray(res.data.routines) ? res.data.routines : []
-      );
+      const routines = Array.isArray(res.data.routines) ? res.data.routines : [];
+      setSavedRoutines(routines);
+
+      // Hydrate the staging scheduler with the latest saved routine items
+      if (routines.length > 0) {
+        const latestRoutine = routines[0];
+        if (Array.isArray(latestRoutine.items)) {
+          const hydrated = latestRoutine.items.map((item) => ({
+            taskId: item.taskId,
+            day: item.day,
+            startTime: item.startTime,
+            duration: item.duration || 60,
+          }));
+          setScheduledTasks(hydrated);
+        }
+      }
     } catch (err) {
       console.error(err);
       setSavedRoutines([]);
@@ -178,7 +211,7 @@ export default function RoutineBuilder() {
 
           <section className="col-span-12 md:col-span-9">
             <WeeklyGrid
-              scheduledTasks={scheduledTasks}
+              scheduledTasks={gridTasks}
               onSaveDay={openSaveRoutineModal}
               onDeleteTask={removeScheduledTask} //Passing Removing function to weeklygrid
             />


### PR DESCRIPTION
📌 Description

While testing the Routine Builder flow, I noticed that the Weekly Schedule grid was resetting to an empty state after page refresh even though routines were being saved correctly in the backend.

This PR restores the latest saved routine back into the scheduler grid during initialization so users can continue working with their previously scheduled tasks after refreshing or revisiting the page.

🔗 Related Issue

Closes #655

🛠 Changes Made

* hydrated `scheduledTasks` from the latest saved routine during page load
* restored Weekly Schedule grid state after refresh/navigation
* added lightweight task lookup mapping using `useMemo`
* preserved existing drag/drop and overlap validation behavior
* added safe fallback handling for async task loading and deleted tasks

📸 Screenshots

Attached screenshots demonstrating:

Before Refresh
<img width="1600" height="762" alt="{747BBDFF-7915-411F-909D-1EDCBB663EBA}" src="https://github.com/user-attachments/assets/ccf4880f-c349-434c-a499-8dac5bba33d8" />

After Refresh
<img width="1595" height="767" alt="{44E4DD27-DC2E-495C-B6D6-18DF61ADEC79}" src="https://github.com/user-attachments/assets/2c0403f8-8971-4c17-8d2f-7870bbe77b11" />

* scheduled tasks before refresh
* restored Weekly Schedule grid after refresh
* persisted routine synchronization

✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console/runtime errors
* [x] Properly tested refresh hydration flow
* [x] Tested drag/drop interactions after hydration
* [x] Verified overlap validation still works
* [x] Linked the issue

🚀 Notes for Reviewers

This PR focuses only on restoring persisted routine state back into the active Weekly Schedule grid while keeping the existing Routine Builder interaction flow unchanged.
