### PR TITLE
Fix: Correct validation order in createRoutine to prevent crash

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -16,7 +16,7 @@ export const createRoutine = async (req, res) => {
 
     // fetch routine details from request body
     const { name, description, items } = req.body;
-    if (!name || items.length == 0 || !items) {
+    if (!name || !items || items.length === 0) {
       return res
         .status(400)
         .json({ success: false, message: "Please enter required details" });


### PR DESCRIPTION
## Fix: Correct validation order in createRoutine to prevent crash

Issue: #317

**Problem:** The validation condition `if (!name || items.length == 0 || !items)`
checks `items.length` before verifying `items` exists. If `items` is `undefined`,
this causes: `Cannot read properties of undefined (reading 'length')`.

**Fix:** Changed order to `if (!name || !items || items.length === 0)`
so `!items` is checked before accessing `items.length`.

Closes #317
