### PR TITLE
fix(ui): use navigator.language instead of hardcoded en-IN locale in LiveClock

### DIFF
--- a/frontend/src/components/Dashboard/LiveClock.jsx
+++ b/frontend/src/components/Dashboard/LiveClock.jsx
@@ -7,7 +7,7 @@ const LiveClock = () => {
     const updateTime = () => {
       const now = new Date();
 
-      const formattedTime = now.toLocaleTimeString("en-IN", {
+      const formattedTime = now.toLocaleTimeString(navigator.language, {
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit",


### PR DESCRIPTION
## Summary
Fixes #657

## Changes
- Replaced hardcoded `"en-IN"` locale with `navigator.language` in `LiveClock.jsx`
- The clock now respects each user's browser/system locale preference
- Non-Indian users will see time in their correct regional format

## Files Changed
- `frontend/src/components/Dashboard/LiveClock.jsx` (1 line changed)

## Type
- [x] Bug fix