### PR TITLE
fix: validate duedate before task creation

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -26,7 +26,7 @@ export const createTask = async (req, res) => {
 
     // fetch details for task from request body
     const { title, description, tags, priority, status, dueDate } = req.body;
-    if (!title || !priority || !status) {
+    if (!title || !priority || !status || !dueDate) {
       return res
         .status(400)
         .json({ success: false, message: "Please enter all the details" });


### PR DESCRIPTION
## 📌 Description
This PR fixes missing validation for the dueDate field in the createTask API.

Earlier, if a request was sent without a due date, it caused a Mongoose validation error and returned a 500 Internal Server Error.
Now the API checks the field before saving the task and returns a 400 Bad Request response.

## 🔗 Related Issue
Closes #498 

## 🛠 Changes Made
- Added duaDate validation in createTask
- Prevented invalid requests from reaching the database save operation
- Fixed incorrect 500 response for missing required field

## 📸 Screenshots (if applicable)
N/A

## ✅ Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch follows the naming convention
- [x] I have tested this locally
- [ ] Linting passes (`npm run lint` in frontend/)
- [x] No unrelated files were modified
- [ ] Screenshots are attached (if UI change)