### PR TITLE
feat: add duplicate routine action

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -121,6 +121,103 @@ export const getRoutines = async (req, res) => {
   }
 };
 
+// Duplicate routine function
+export const duplicateRoutine = async (req, res) => {
+  try {
+    // check if user is logged in or not
+    const userId = req.userId;
+    const user = await User.findById(userId);
+    if (!user) {
+      return res
+        .status(401)
+        .json({ success: false, message: "Unauthorized, user not logged in" });
+    }
+
+    // validate the optional target day before creating the copy
+    const validDays = [
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+      "Sunday",
+    ];
+    const { targetDay } = req.body;
+    if (targetDay && !validDays.includes(targetDay)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid target day" });
+    }
+
+    // fetch the source routine for this user only
+    const routineId = req.params.id;
+    const sourceRoutine = await Routine.findOne({ _id: routineId, userId });
+    if (!sourceRoutine) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Routine not found" });
+    }
+
+    const duplicatedItems = sourceRoutine.items.map((item) => ({
+      taskId: item.taskId,
+      day: targetDay || item.day,
+      startTime: item.startTime,
+      duration: item.duration,
+    }));
+
+    if (targetDay) {
+      const formatted = duplicatedItems
+        .map((item) => ({
+          day: item.day,
+          startTime: item.startTime,
+          endTime: item.startTime + item.duration,
+        }))
+        .sort((a, b) => a.startTime - b.startTime);
+
+      if (checkOverlap(formatted)) {
+        return res.status(400).json({
+          success: false,
+          message: `Copied tasks overlap on ${targetDay}`,
+        });
+      }
+    }
+
+    const baseRoutineName = sourceRoutine.name
+      .replace(/(\s*\(Copy\))+$/g, "")
+      .trim();
+
+    // If the routine name contains a weekday, rename it for the selected day.
+    const duplicatedName = targetDay
+      ? baseRoutineName.replace(
+        /\b(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\b/g,
+        targetDay
+      )
+      : baseRoutineName;
+
+    // copy routine-owned fields and let MongoDB create fresh document ids
+    const duplicatedRoutine = new Routine({
+      userId,
+      name: `${duplicatedName} (Copy)`,
+      description: sourceRoutine.description,
+      items: duplicatedItems,
+    });
+
+    await duplicatedRoutine.save();
+    return res.status(201).json({
+      success: true,
+      message: "Routine duplicated successfully",
+      routine: duplicatedRoutine,
+    });
+  } catch (error) {
+    // error handling
+    console.log("Error duplicating routine", error);
+    return res
+      .status(500)
+      .json({ success: false, message: "Error duplicating routine" });
+  }
+};
+
 // Update routine function
 export const updateRoutine = async (req, res) => {
   try {

--- a/backend/routes/routineRoutes.js
+++ b/backend/routes/routineRoutes.js
@@ -2,6 +2,7 @@ import express from "express";
 import {
   createRoutine,
   deleteRoutine,
+  duplicateRoutine,
   getRoutines,
   updateRoutine,
 } from "../controllers/routineController.js";
@@ -15,6 +16,9 @@ routineRouter.post("/", authMiddleware, createRoutine);
 
 // Route for fetching routines
 routineRouter.get("/", authMiddleware, getRoutines);
+
+// Route for duplicating routine
+routineRouter.post("/:id/duplicate", authMiddleware, duplicateRoutine);
 
 // Route for updating routine
 routineRouter.put("/:id", authMiddleware, updateRoutine);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
-import { CheckCircle2, Calendar, Flame, ArrowRight } from "lucide-react";
+import { CheckCircle2, Calendar, ArrowRight, Copy } from "lucide-react";
 import LiveClock from "../components/Dashboard/LiveClock";
 
 
@@ -11,6 +11,7 @@ import DashboardTasks from "../components/Dashboard/DashboardTasks";
 import api from "../api/axios.js";
 import useTasks from "../hooks/useTasks.js";
 import { getGreeting } from "../utils/getGreeting";
+import { DAYS_OF_WEEK } from "../utils/constants";
 
 export default function Dashboard() {
   const { user } = useContext(AuthContext);
@@ -18,6 +19,9 @@ export default function Dashboard() {
 
   const [savedRoutines, setSavedRoutines] = useState([]);
   const [loadingRoutines, setLoadingRoutines] = useState(false);
+  const [duplicatingRoutineId, setDuplicatingRoutineId] = useState(null);
+  const [routineToDuplicate, setRoutineToDuplicate] = useState(null);
+  const [duplicateTargetDay, setDuplicateTargetDay] = useState(DAYS_OF_WEEK[0]);
 
   const { tasks, updateTask } = useTasks();
 
@@ -93,6 +97,44 @@ export default function Dashboard() {
   useEffect(() => {
     fetchRoutines();
   }, []);
+
+  const openDuplicateModal = (routine) => {
+    setRoutineToDuplicate(routine);
+    setDuplicateTargetDay(routine.items[0]?.day || DAYS_OF_WEEK[0]);
+  };
+
+  const closeDuplicateModal = () => {
+    setRoutineToDuplicate(null);
+    setDuplicateTargetDay(DAYS_OF_WEEK[0]);
+  };
+
+  const handleDuplicateRoutine = async () => {
+    if (!routineToDuplicate) return;
+
+    try {
+      setDuplicatingRoutineId(routineToDuplicate._id);
+      const res = await api.post(
+        `/routines/${routineToDuplicate._id}/duplicate`,
+        { targetDay: duplicateTargetDay }
+      );
+
+      // Add the new routine immediately so the card appears without a full refresh.
+      if (res.data.routine) {
+        setSavedRoutines((prevRoutines) => [
+          res.data.routine,
+          ...prevRoutines,
+        ]);
+      } else {
+        await fetchRoutines();
+      }
+      closeDuplicateModal();
+    } catch (err) {
+      console.error(err);
+      alert("Failed to duplicate routine");
+    } finally {
+      setDuplicatingRoutineId(null);
+    }
+  };
 
   return (
     <div className="min-h-screen w-full max-w-[1440px] mx-auto app-bg px-6 py-8 space-y-8 animate-in">
@@ -186,7 +228,19 @@ export default function Dashboard() {
                   key={routine._id}
                   className="border-l-4 border-primary rounded-xl p-4 bg-white/80 hover:bg-white dark:bg-slate-800/80 dark:hover:bg-slate-800 shadow-sm hover:shadow-md transition-all duration-200 animate-in"
                 >
-                  <p className="font-medium text-main">{routine.name}</p>
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="font-medium text-main">{routine.name}</p>
+                    <button
+                      type="button"
+                      onClick={() => openDuplicateModal(routine)}
+                      disabled={duplicatingRoutineId === routine._id}
+                      aria-label={`Duplicate ${routine.name}`}
+                      title="Duplicate routine"
+                      className="shrink-0 rounded-lg p-2 text-muted hover:text-primary hover:bg-primary/10 disabled:opacity-50 disabled:cursor-not-allowed transition cursor-pointer"
+                    >
+                      <Copy size={16} />
+                    </button>
+                  </div>
                   {routine.description && (
                     <p className="text-xs text-muted mt-0.5 line-clamp-2 italic">
                       {routine.description}
@@ -202,6 +256,52 @@ export default function Dashboard() {
           )}
         </div>
       </section>
+
+      {routineToDuplicate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="card card-primary w-full max-w-sm">
+            <h3 className="text-lg font-semibold text-main">
+              Duplicate Routine
+            </h3>
+            <p className="mt-1 text-sm text-muted">
+              Choose the day for "{routineToDuplicate.name} (Copy)".
+            </p>
+
+            <label className="mt-4 block text-sm font-medium text-main">
+              Copy to
+            </label>
+            <select
+              value={duplicateTargetDay}
+              onChange={(e) => setDuplicateTargetDay(e.target.value)}
+              className="mt-2 w-full rounded-lg border-soft bg-transparent px-3 py-2 text-sm text-main focus:outline-none"
+            >
+              {DAYS_OF_WEEK.map((day) => (
+                <option key={day} value={day}>
+                  {day}
+                </option>
+              ))}
+            </select>
+
+            <div className="mt-5 flex justify-end gap-3">
+              <button
+                type="button"
+                className="btn btn-muted"
+                onClick={closeDuplicateModal}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary cursor-pointer"
+                onClick={handleDuplicateRoutine}
+                disabled={duplicatingRoutineId === routineToDuplicate._id}
+              >
+                Duplicate
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description
Added duplicate routine functionality. Users can duplicate a saved routine from the Dashboard, choose the target day, and create a copied routine with an updated name.

## Related Issue
Closes #72

## Changes Made
- Added `POST /api/routines/:id/duplicate`
- Added Dashboard copy icon for saved routine cards
- Added target-day selection before duplicating a routine
- Updated duplicate routine names to use the selected day
- Prevented repeated `(Copy)` suffix spam

## Screen Recording
https://github.com/user-attachments/assets/32e7f8ad-7589-4c84-87cc-3092f6d908a8

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch follows the naming convention
- [x] I have tested this locally
- [x] Linting passes (`npm run lint` in frontend/)
- [x] No unrelated files were modified
- [x] Screen recording is attached