### PR TITLE
accessible-icon-name added

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -31,7 +31,9 @@ export default function Footer() {
               <a 
                 href={githubBase} 
                 target="_blank" 
-                rel="noreferrer" 
+                rel="noreferrer"
+                aria-label="DailyForge GitHub repository"
+                title="DailyForge GitHub repository"
                 className="p-2 bg-white/5 rounded-lg text-[#6dd5c7] hover:bg-[#4eb7b3] hover:text-white transition-all border border-white/10"
               >
                 <Github size={18} />


### PR DESCRIPTION
## 📌 Description
This PR improves accessibility in the footer by adding an accessible name to the icon-only GitHub link

## 🔗 Related Issue
Closes #<684>

## 🛠 Changes Made
- Added aria-label to the GitHub footer link
- Added title attribute for better accessibility support
- Improved screen reader compatibility for the icon-only link
- Resolved unnamed link accessibility issue in the footer





