### PR TITLE
Fix Tasks page Trash2 runtime crash

### DIFF
--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import useTasks from "../hooks/useTasks";
 import TaskItem from "../components/Task/TaskItem";
 import TaskFormModal from "../components/Task/TaskFormModal";
-import { Plus, ArrowLeft, Filter } from "lucide-react";
+import { Plus, ArrowLeft, Filter, Trash2 } from "lucide-react";
 import { CATEGORIES } from "../utils/categoryUtils";
 import EmptyState from "../components/EmptyState";
 


### PR DESCRIPTION
## Summary
- import `Trash2` in `frontend/src/pages/Tasks.jsx` where the bulk delete button renders it
- fix the runtime `ReferenceError: Trash2 is not defined` crash on the Tasks page

Fixes #712
Also fixes #706

## Validation
- `git diff --check` passed
- `node --check frontend/src/pages/Tasks.jsx` is not supported for `.jsx` files in this local Node-only shell (`ERR_UNKNOWN_FILE_EXTENSION`), so I kept the change to a single missing import already used elsewhere in the project.

## GSSoC labels requested
If accepted, please add `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`.
