### PR TITLE
fix: dynamic "Go Home" button label on 404 page based on auth state

### DIFF
--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -28,7 +28,7 @@ const NotFound = () => {
         onClick={handleGoHome}
         className="btn btn-primary hover-lift cursor-pointer"
       >
-        Go Home
+        {token ? "Go to Dashboard" : "Go to Login"}
       </button>
     </div>
   );


### PR DESCRIPTION
## 📌 Description
Fixed a UX issue on the 404 Not Found page where the "Go Home" button always showed the same label regardless of the user's auth state. A logged-in user had no idea the button would take them to the dashboard, and a logged-out user had no idea it would take them to login. Now the button label reflects the actual destination - making the experience clearer and less confusing.

## 🔗 Related Issue
Closes #533 

## 🛠 Changes Made
- Updated `frontend/src/pages/NotFound.jsx` - button label now conditionally renders based on token
  - Logged-in user ->`"Go to Dashboard"`
  - Logged-out user  -> `"Go to Login"`
- No logic changes - navigation behavior stays exactly the same, only the label is updated


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
This is a one-line change in `NotFound.jsx` - minimal risk.
1. Logged-in user hits a bad URL -> should see **"Go to Dashboard"** and land on `/dashboard`
2. Logged-out user hits a bad URL -> should see **"Go to Login"** and land on `/login`