### PR TITLE
fix(tasks): allow editing overdue tasks without changing due date

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -40,7 +40,8 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
     if (!priority) return onError?.("Priority is required");
     if (!dueDate) return onError?.("Due date is required");
 
-    if (dueDate < todayStr) {
+    const isOriginalDate = task && dueDate === task.dueDate.split("T")[0];
+    if (!isOriginalDate && dueDate < todayStr) {
       return alert("Due date cannot be in the past");
     }
     


### PR DESCRIPTION
## Summary
Fixes #745

## Changes
- Updated the date validation logic in `TaskFormModal.jsx`.
- When an existing task is being edited, the form now checks if the `dueDate` is identical to the original date.
- The "Due date cannot be in the past" alert is bypassed if the date was unmodified, allowing users to safely edit the title, description, or tags of an overdue task.

## Files Changed
- `frontend/src/components/Task/TaskFormModal.jsx`

## Type
- [x] Bug fix
