### PR TITLE
Feature/task due time

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -181,15 +181,13 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
           <div>
             <label className="text-sm font-medium text-main">Due Date</label>
             <input
-              type="date"
+              type="datetime-local"
               value={dueDate}
-              min={todayStr}
-              max={maxDateStr}
               onChange={(e) => setDueDate(e.target.value)}
-              onClick={(e) => e.target.showPicker?.()}
+              onClick={(e) => e.target.showPicker && e.target.showPicker()}
               className="w-full mt-1 p-2 border border-soft rounded-lg focus:ring-(--primary) focus:border-(--primary) bg-transparent text-main"
               required
-            />
+/>
           </div>
 
           {/* Submit Button */}

--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -27,7 +27,14 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
       setDescription(task.description || "");
       setTags(Array.isArray(task.tags) ? task.tags : []);
       setPriority(task.priority || "Low");
-      setDueDate(task.dueDate ? task.dueDate.split("T")[0] : "");
+      setDueDate(
+        task.dueDate
+        ? new Date(task.dueDate)
+        .toLocaleString("sv-SE")
+        .replace(" ", "T")
+        .slice(0, 16)
+        : ""
+      );
       /* eslint-enable react-hooks/set-state-in-effect */
     }
     onError?.("");


### PR DESCRIPTION
## 📌 Description
Added support for task due date and time using `datetime-local`.

## 🔗 Related Issue
Closes #719 

## 🛠 Changes Made

- Replaced date input with datetime input
- Added datetime persistence while editing tasks
- Fixed datetime formatting issues in edit mode
- Fixed timezone/local datetime handling
- Updated countdown behavior to work with exact task times

 
## Testing

* Created tasks with date and time
* Edited tasks and verified datetime persistence
* Tested countdown updates
* Verified MongoDB storage and retrieval

## 📸 Screenshots (if applicable)
<img width="300" height="490" alt="Screenshot 2026-05-19 131155" src="https://github.com/user-attachments/assets/aa076ea0-870b-4842-b84a-c0cff34b4c9b" />

<img width="389" height="402" alt="img1" src="https://github.com/user-attachments/assets/8b806c65-89ab-4d53-b252-d01ac23dac24" />

<img width="468" height="220" alt="Screenshot 2026-05-19 135124" src="https://github.com/user-attachments/assets/67579269-b820-4b66-b586-3e035a65df01" />

## ✅ Checklist
- [Y ] Code runs locally
- [Y ] Followed project structure
- [Y] No console errors
- [Y ] Properly tested changes
- [Y ] Linked the issue

## 🚀 Notes for Reviewers

Implemented datetime support for task due dates using `datetime-local`.

Additional fixes included:
* Preserved datetime values while editing tasks
* Fixed timezone/local datetime formatting issues
* Updated countdown behavior to work with exact task times

Tested locally with:
* task creation
* task editing
* page refresh persistence
* MongoDB storage/retrieval

Some optional enhancements mentioned in the issue (such as optional start/end time and expanded dashboard time display) were intentionally left out to keep this PR focused and stable.
