### PR TITLE
fix: add accessible name to footer GitHub link

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -32,6 +32,8 @@ export default function Footer() {
                 href={githubBase} 
                 target="_blank" 
                 rel="noreferrer" 
+                aria-label="DailyForge GitHub repository"
+                title="DailyForge GitHub repository"
                 className="p-2 bg-white/5 rounded-lg text-[#6dd5c7] hover:bg-[#4eb7b3] hover:text-white transition-all border border-white/10"
               >
                 <Github size={18} />


### PR DESCRIPTION
## 📌 Description
Added an accessible name to the icon-only GitHub repository link in the footer so assistive technologies announce it clearly.

## 🔗 Related Issue
Closes #684

## 🛠 Changes Made
- Added `aria-label="DailyForge GitHub repository"` to the footer GitHub icon link.
- Added a matching `title` attribute for tooltip/accessibility support.

## 📸 Screenshots (if applicable)
No visual UI changes.

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
This is an accessibility-only change and does not alter the footer layout or styling.