### PR TITLE
fix: correct navbar active state for login and signup routes

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -121,18 +121,33 @@ const Navbar = () => {
 
             {!user ? (
               <>
-                <Link
+                <NavLink
                   to="/login"
-                  className="text-sm font-medium text-[#4eb7b3] hover:text-[#3b8ea0] transition-colors px-4 py-2 rounded-xl hover:bg-[#d0f6e3]/50"
-                >
-                  Login
-                </Link>
-                <Link 
-                  to="/signup" 
-                  className="btn btn-primary text-sm shadow-md hover:shadow-lg transition-all"
-                >
-                  Signup
-                </Link>
+                  className={({ isActive }) =>
+                    cn(
+                        "text-sm font-medium px-4 py-2 rounded-xl transition-colors",
+                        isActive
+                        ? "bg-[#d0f6e3] text-[#3b8ea0]"
+                        : "text-gray-400 hover:text-[#3b8ea0] hover:bg-[#d0f6e3]/50"
+                     )
+                   }
+                 >
+                   Login
+                </NavLink>
+
+                <NavLink
+                  to="/signup"
+                  className={({ isActive }) =>
+                     cn(
+                         "text-sm px-4 py-2 rounded-xl transition-all",
+                           isActive
+                           ? "bg-[#d0f6e3] text-[#3b8ea0]"
+                           : "text-gray-400 hover:text-[#3b8ea0] hover:bg-[#d0f6e3]/50"
+                      )
+                   }
+                  >
+                    Signup
+                </NavLink>
               </>
             ) : (
               <button 


### PR DESCRIPTION
## 📌 Description
Fixed the navbar active state issue where the Signup button remained highlighted regardless of the current route.

The issue was caused because Login and Signup were using `Link` instead of `NavLink`, which prevented route-based active styling. Updated the implementation to use active route detection and corrected inactive styling behavior.

## 🔗 Related Issue
Closes #768

## 🛠 Changes Made
- Replaced `Link` with `NavLink` for Login and Signup buttons
- Added route-based active styling using `isActive`
- Fixed inactive button styling so only the current route is highlighted
- Tested behavior on `/login` and `/signup`

## 📸 Screenshots (if applicable)
Verified:
- `/login` → only Login highlighted
- `/signup` → only Signup highlighted

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [ ] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Please review the active state behavior for authentication routes and confirm UI consistency.