### PR TITLE
fix(backend): add duplicate check to updateTask

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -113,17 +113,46 @@ export const updateTask = async (req, res) => {
     const updates = req.body;
     const taskId = req.params.id;
 
+    // Fetch existing task to check for conflicts
+    const existingTask = await Task.findOne({ _id: taskId, userId: userId });
+    if (!existingTask) {
+      return res.status(404).json({
+        message: "Task not found",
+      });
+    }
+
+    if (updates.title || updates.dueDate) {
+      const updatedTitle = updates.title || existingTask.title;
+      const updatedDueDate = new Date(updates.dueDate || existingTask.dueDate);
+
+      if (!Number.isNaN(updatedDueDate.getTime())) {
+        const dateStart = new Date(updatedDueDate);
+        dateStart.setUTCHours(0, 0, 0, 0);
+        const dateEnd = new Date(dateStart);
+        dateEnd.setUTCDate(dateEnd.getUTCDate() + 1);
+
+        const conflict = await Task.findOne({
+          userId,
+          _id: { $ne: taskId },
+          title: { $regex: new RegExp(`^${escapeRegex(updatedTitle.trim())}$`, "i") },
+          dueDate: { $gte: dateStart, $lt: dateEnd },
+        });
+
+        if (conflict) {
+          return res.status(409).json({
+            success: false,
+            message: "A task with the same title and due date already exists",
+          });
+        }
+      }
+    }
+
     // fetch task from database and update
     const updatedTask = await Task.findOneAndUpdate(
       { _id: taskId, userId: userId },
       { $set: updates },
       { new: true, runValidators: true }
     );
-    if (!updatedTask) {
-      return res.status(404).json({
-        message: "Task not found",
-      });
-    }
     return res.status(200).json({
       message: "Task updated successfully",
       task: updatedTask,


### PR DESCRIPTION
## Description
This PR fixes an issue where users could bypass task uniqueness constraints by updating an existing task. 

While `createTask` prevented duplicate tasks with the exact same title and due date, `updateTask` lacked this validation. This allowed a user to rename an existing task (or change its due date) to perfectly match another task, creating duplicates in the database.

This fix adds a conflict check within `updateTask` that queries the database for existing tasks with the same `title` and `dueDate` combination (excluding the current task itself) before applying the update. If a conflict is found, it correctly rejects the request with an HTTP 409 status code.

##  Related Issues
Resolves #819

##  Changes Made
- Added a `Task.findOne` conflict check in `backend/controllers/taskController.js` inside the `updateTask` function.
- Ensures the check ignores the current task being modified using `_id: { $ne: taskId }`.
- Returns an HTTP 409 conflict status if a duplicate is found, matching the behavior of `createTask`.
