### PR TITLE
fix: correct invalid SVG attribute strokeLinedasharray to strokeDasharray in EmptyState

### DIFF
--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -20,7 +20,7 @@ const CONFIG = {
     icon: (
       <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ width: 80, height: 80 }}>
         <circle cx="40" cy="40" r="28" stroke="#6366f1" strokeWidth="3" opacity="0.2" />
-        <circle cx="40" cy="40" r="28" stroke="#6366f1" strokeWidth="3" strokeLinedasharray="44 132" strokeLinecap="round" opacity="0.7" />
+        <circle cx="40" cy="40" r="28" stroke="#6366f1" strokeWidth="3" strokeDasharray="44 132" strokeLinecap="round" opacity="0.7" />
         <circle cx="40" cy="40" r="3" fill="#6366f1" />
         <path d="M40 40 V20" stroke="#6366f1" strokeWidth="2.5" strokeLinecap="round" />
         <path d="M40 40 L54 48" stroke="#6366f1" strokeWidth="2" strokeLinecap="round" opacity="0.6" />


### PR DESCRIPTION
## 📌 Description
Fixed a typo in the routines SVG inside `EmptyState.jsx` where `strokeLinedasharray` was used instead of the correct `strokeDasharray`. This caused the clock icon's arc to render as a full solid circle, completely ignoring the intended dashed partial arc effect. Since SVG silently ignores unknown attributes, this produced no console error and was easy to miss.

## 🔗 Related Issue
Closes #823 

## 🛠 Changes Made
- Fixed typo in `frontend/src/components/EmptyState.jsx`
- Changed `strokeLinedasharray="44 132"` -> `strokeDasharray="44 132"` on the clock arc circle in the routines SVG
- One character change, no logic or layout touched

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Single attribute typo fix in one file.