### PR TITLE
fix: intercept routine-prefixed task IDs before API call, add ObjectId validation

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -1,6 +1,7 @@
-import Task from "../src/models/Task.js";
+﻿import Task from "../src/models/Task.js";
 import User from "../src/models/User.js";
 import { validationResult } from "express-validator";
+import mongoose from "mongoose";
 
 const escapeRegex = (text) => text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -101,7 +102,7 @@ export const getTasks = async (req, res) => {
       return res
         .status(200)
         .json({ success: true, tasks: [] });
-  }
+    }
     return res.status(200).json({ success: true, tasks });
   } catch (error) {
     // error handling
@@ -124,6 +125,15 @@ export const updateTask = async (req, res) => {
         .json({ success: false, message: "Unauthorized, token invalid" });
     }
 
+    // Validate that taskId is a valid MongoDB ObjectId before attempting cast
+    const taskId = req.params.id;
+    if (!mongoose.Types.ObjectId.isValid(taskId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid task ID format",
+      });
+    }
+
     // check for validation errors
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
@@ -136,7 +146,6 @@ export const updateTask = async (req, res) => {
 
     // fetch update task details
     const updates = req.body;
-    const taskId = req.params.id;
 
     // fetch task from database and update
     const updatedTask = await Task.findOneAndUpdate(
@@ -174,8 +183,14 @@ export const deleteTask = async (req, res) => {
         .json({ success: false, message: "Unauthorized, token invalid" });
     }
 
-    // fetch task id
+    // Validate that taskId is a valid MongoDB ObjectId before attempting cast
     const taskId = req.params.id;
+    if (!mongoose.Types.ObjectId.isValid(taskId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid task ID format",
+      });
+    }
 
     // fetch task to be deleted from database
     const deleteTask = await Task.findOneAndDelete({

--- a/frontend/src/hooks/useMixedTasks.js
+++ b/frontend/src/hooks/useMixedTasks.js
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Custom hook to handle updates for both DB-backed tasks and routine-generated tasks.
+ * 
+ * Routine tasks have synthetic IDs prefixed with "routine-" and are stored in localStorage only.
+ * DB tasks have valid MongoDB ObjectIds and use the API.
+ * 
+ * @param {Function} updateDbTask API-backed task updater from useTasks
+ * @returns {Object} { updateTask, routineTasks, setRoutineTasks }
+ */
+const useMixedTasks = (updateDbTask) => {
+  const [routineTasks, setRoutineTasks] = useState(() => {
+    const stored = localStorage.getItem("activeRoutineTasks");
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  useEffect(() => {
+    const syncRoutineTasks = (event) => {
+      if (event?.type === "activeRoutineTasksUpdated" && Array.isArray(event?.detail)) {
+        setRoutineTasks(event.detail);
+        return;
+      }
+
+      const stored = localStorage.getItem("activeRoutineTasks");
+      setRoutineTasks(stored ? JSON.parse(stored) : []);
+    };
+
+    window.addEventListener("storage", syncRoutineTasks);
+    window.addEventListener("activeRoutineTasksUpdated", syncRoutineTasks);
+
+    return () => {
+      window.removeEventListener("storage", syncRoutineTasks);
+      window.removeEventListener("activeRoutineTasksUpdated", syncRoutineTasks);
+    };
+  }, []);
+
+  /**
+   * Smart update handler that detects task type and routes appropriately
+   * @param {string} id - Task ID (either valid ObjectId or routine-*)
+   * @param {Object} updates - Fields to update
+   */
+  const updateTask = async (id, updates) => {
+    // Check if this is a routine task (synthetic ID with routine- prefix)
+    if (id && String(id).startsWith("routine-")) {
+      // Handle routine task locally
+      let result;
+      setRoutineTasks((prev) => {
+        const updated = prev.map((task) =>
+          task._id === id ? { ...task, ...updates } : task
+        );
+        // Persist to localStorage (wrap in try/catch for safety)
+        try {
+          localStorage.setItem("activeRoutineTasks", JSON.stringify(updated));
+        } catch (error) {
+          // ignore localStorage failures
+          console.error("Failed to persist routine tasks to localStorage", error);
+        }
+        // Dispatch a dedicated custom event so same-tab listeners can subscribe
+        try {
+          window.dispatchEvent(
+            new CustomEvent("activeRoutineTasksUpdated", { detail: updated })
+          );
+        } catch {
+          // fallback to a generic event
+          window.dispatchEvent(new Event("activeRoutineTasksUpdated"));
+        }
+        result = updated.find((t) => t._id === id);
+        return updated;
+      });
+      // return the updated task for callers that await this
+      return result;
+    }
+
+    if (typeof updateDbTask === "function") {
+      // Handle DB-backed task via API
+      await updateDbTask(id, updates);
+    }
+  };
+
+  return { updateTask, routineTasks, setRoutineTasks };
+};
+
+export default useMixedTasks;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -10,6 +10,7 @@ import TaskPreview from "../components/Dashboard/TaskPreview";
 import DashboardTasks from "../components/Dashboard/DashboardTasks";
 import api from "../api/axios.js";
 import useTasks from "../hooks/useTasks.js";
+import useMixedTasks from "../hooks/useMixedTasks.js";
 import { getGreeting } from "../utils/getGreeting";
 import { DAYS_OF_WEEK } from "../utils/constants";
 
@@ -19,12 +20,12 @@ export default function Dashboard() {
 
   const [savedRoutines, setSavedRoutines] = useState([]);
   const [loadingRoutines, setLoadingRoutines] = useState(false);
-  const [routineTasks, setRoutineTasks] = useState([]);
   const [duplicatingRoutineId, setDuplicatingRoutineId] = useState(null);
   const [routineToDuplicate, setRoutineToDuplicate] = useState(null);
   const [duplicateTargetDay, setDuplicateTargetDay] = useState(DAYS_OF_WEEK[0]);
 
-  const { tasks, updateTask } = useTasks();
+  const { tasks, updateTask: updateDbTask } = useTasks();
+  const { updateTask, routineTasks } = useMixedTasks(updateDbTask);
 
   const today = new Date();
  
@@ -97,29 +98,6 @@ export default function Dashboard() {
   useEffect(() => {
     fetchRoutines();
   }, []);
-  useEffect(() => {
-
-  const loadRoutineTasks = () => {
-
-    const storedRoutineTasks = localStorage.getItem(
-      "activeRoutineTasks"
-    );
-
-    if (storedRoutineTasks) {
-      setRoutineTasks(JSON.parse(storedRoutineTasks));
-    } else {
-      setRoutineTasks([]);
-    }
-  };
-
-  loadRoutineTasks();
-
-  window.addEventListener("storage", loadRoutineTasks);
-
-return () => {
-  window.removeEventListener("storage", loadRoutineTasks);
-};
-}, []);
 
 const openDuplicateModal = (routine) => {
   setRoutineToDuplicate(routine);


### PR DESCRIPTION
## Description
Fixes routine task completion in Today's Focus by separating update paths for routine local tasks and DB-backed tasks.
Routine tasks with synthetic IDs (prefixed with `routine-`) now update locally and persist in localStorage instead of hitting the task update API.
DB-backed tasks continue to use the existing API update flow.
Also adds defensive backend validation for task IDs to prevent invalid ID format from causing CastError/500 responses.

## Related Issue
Closes #788 

## Changes Made
- Added mixed task update handling so routine-prefixed task IDs are intercepted before API calls.
- Updated routine task completion to persist in localStorage.
- Kept API update behavior unchanged for valid DB-backed task IDs.
- Added backend ObjectId format checks in task update/delete handlers.

## Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## Notes for Reviewers
Please verify:
1. Toggling a routine task updates instantly in UI and persists after refresh.
2. No API request is fired for routine-prefixed task IDs.
3. Toggling DB-backed tasks still uses API update flow.
4. Invalid task IDs now return a controlled bad request response instead of CastError/500.