### PR TITLE
fix: correct password visibility toggle icon behavior

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -120,7 +120,7 @@ const Login = () => {
             className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-main transition-colors cursor-pointer flex items-center justify-center"
             aria-label={showPassword ? "Hide password" : "Show password"}
           >
-            {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            {showPassword ? <Eye size={18} /> : <EyeOff size={18} />}
           </button>
         </div>
       </div>

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -191,7 +191,7 @@ const Signup = () => {
             className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-main transition-colors cursor-pointer flex items-center justify-center"
             aria-label={showPassword ? "Hide password" : "Show password"}
           >
-            {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            {showPassword ? <Eye size={18} /> : <EyeOff size={18} />}
           </button>
         </div>
         {errors.password && <span className="text-red-500 text-xs">{errors.password}</span>}


### PR DESCRIPTION
## 📌 Description
Fixed the reversed password visibility toggle icon behavior in both Login and Signup forms.

Previously:
- The open eye icon appeared when the password was hidden.
- The slashed eye icon appeared when the password was visible.

Now:
- The open eye icon correctly indicates visible password text.
- The slashed eye icon correctly indicates hidden password text.

## 🔗 Related Issue
Closes #742

## 🛠️ Changes Made
- Fixed password visibility toggle logic in `Login.jsx`
- Fixed password visibility toggle logic in `Signup.jsx`
- Updated icon rendering to match standard UX behavior
- Verified toggle behavior for both password and confirm password fields

## 📸 Screenshots (if applicable)
Added screenshots demonstrating:
- Hidden password state with slashed eye icon
- Visible password state with open eye icon

<img width="554" height="171" alt="Screenshot 2026-05-20 234523" src="https://github.com/user-attachments/assets/f570f7aa-c485-432e-b292-a9f4435736d0" />

<img width="557" height="148" alt="Screenshot 2026-05-20 234532" src="https://github.com/user-attachments/assets/261503dd-c887-4475-b970-5bc2d81cca25" />


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
This is a frontend UI/UX fix only. No backend logic was modified.
