### PR TITLE
fix: guard against undefined items in createRoutine

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -16,7 +16,7 @@ export const createRoutine = async (req, res) => {
 
     // fetch routine details from request body
     const { name, description, items } = req.body;
-    if (!name || items.length == 0 || !items) {
+    if (!name || !items || items.length === 0) {
       return res
         .status(400)
         .json({ success: false, message: "Please enter required details" });


### PR DESCRIPTION
## 📌 Description
Fixed a bug in `createRoutine` where accessing `items.length` before 
checking `!items` caused an unhandled `TypeError` when the `items` 
field was missing from the request body, crashing the server instead 
of returning a clean 400 validation error.

## 🔗 Related Issue
Closes #846 

## 🛠 Changes Made
- Reordered the null check condition in `createRoutine` to guard 
  `!items` before accessing `items.length`
- Changed `==` to `===` for strict equality

## 📸 Screenshots (if applicable)
N/A — backend logic fix, no UI changes

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
The condition on line 19 of `routineController.js` was:
`if (!name || items.length == 0 || !items)`

This crashes with `TypeError: Cannot read properties of undefined 
(reading 'length')` when `items` is not provided in the request body,
because `items.length` is evaluated before `!items` is checked.

Fixed to: `if (!name || !items || items.length === 0)`