### PR TITLE
[SECURITY] Harden JWT cookie/session security

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -4,6 +4,35 @@ import jwt from 'jsonwebtoken';
 import { verifyFirebaseIdToken } from '../utils/firebaseAuth.js';
 import crypto from 'crypto';
 
+const JWT_ALGORITHM = process.env.JWT_ALGORITHM || 'HS256';
+const AUTH_COOKIE_MAX_AGE = 24 * 60 * 60 * 1000;
+
+const getJwtSecret = (res) => {
+  if (!process.env.JWT_SECRET) {
+    res.status(500).json({ message: 'Authentication service is misconfigured' });
+    return null;
+  }
+
+  return process.env.JWT_SECRET;
+};
+
+const getAuthCookieOptions = () => {
+  const cookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/',
+    maxAge: AUTH_COOKIE_MAX_AGE,
+  };
+
+  const cookieDomain = process.env.AUTH_COOKIE_DOMAIN || process.env.COOKIE_DOMAIN;
+  if (cookieDomain) {
+    cookieOptions.domain = cookieDomain;
+  }
+
+  return cookieOptions;
+};
+
 // sign up function
 export const signup = async (req, res) => {
   try {
@@ -43,23 +72,24 @@ export const signup = async (req, res) => {
     // save the new user in database
     await newUser.save();
 
+    const jwtSecret = getJwtSecret(res);
+    if (!jwtSecret) {
+      return;
+    }
+
     // generate token using jwt
-    const token = jwt.sign({ userId: newUser._id }, process.env.JWT_SECRET, {
-      expiresIn: '24h',
+    const token = jwt.sign({ userId: newUser._id }, jwtSecret, {
+      expiresIn: process.env.JWT_EXPIRES_IN || '24h',
+      algorithm: JWT_ALGORITHM,
     });
 
     return res
       .status(201)
-      .cookie('token', token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        maxAge: 24 * 60 * 60 * 1000,
-      })
-      .json({ 
-  message: 'User registered successfully',
-  user: { _id: newUser._id, name: newUser.name, email: newUser.email }
-});
+      .cookie('token', token, getAuthCookieOptions())
+      .json({
+        message: 'User registered successfully',
+        user: { _id: newUser._id, name: newUser.name, email: newUser.email },
+      });
   } catch (error) {
     // error handling
     console.error('Signup error:', error);
@@ -92,23 +122,24 @@ export const login = async (req, res) => {
       return res.status(401).json({ message: 'Password does not match' });
     }
 
+    const jwtSecret = getJwtSecret(res);
+    if (!jwtSecret) {
+      return;
+    }
+
     // generate jwt token
-    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
-      expiresIn: '24h',
+    const token = jwt.sign({ userId: user._id }, jwtSecret, {
+      expiresIn: process.env.JWT_EXPIRES_IN || '24h',
+      algorithm: JWT_ALGORITHM,
     });
 
     return res
       .status(200)
-      .cookie('token', token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        maxAge: 24 * 60 * 60 * 1000,
-      })
-      .json({ 
-  message: 'Login successful',
-  user: { _id: user._id, name: user.name, email: user.email }
-});
+      .cookie('token', token, getAuthCookieOptions())
+      .json({
+        message: 'Login successful',
+        user: { _id: user._id, name: user.name, email: user.email },
+      });
   } catch (error) {
     // error handling
     console.log('Login error: ', error);
@@ -205,11 +236,7 @@ export const updateProfile = async (req, res) => {
 
 // logout function
 export const logout = (req, res) => {
-  res.clearCookie('token', {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
-  });
+  res.clearCookie('token', getAuthCookieOptions());
   return res.status(200).json({ message: 'Logout successful' });
 };
 
@@ -260,19 +287,20 @@ export const googleLogin = async (req, res) => {
     }
 
     // Generate JWT token (matches standard custom auth format)
-    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
+    const jwtSecret = getJwtSecret(res);
+    if (!jwtSecret) {
+      return;
+    }
+
+    const token = jwt.sign({ userId: user._id }, jwtSecret, {
       expiresIn: process.env.JWT_EXPIRES_IN || '24h',
+      algorithm: JWT_ALGORITHM,
     });
 
     // Write token to HTTP-Only Cookie
     return res
       .status(200)
-      .cookie('token', token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        maxAge: 24 * 60 * 60 * 1000,
-      })
+      .cookie('token', token, getAuthCookieOptions())
       .json({
         message: 'Google sign-in successful',
         user: {

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -1,4 +1,6 @@
-import jwt from "jsonwebtoken";
+import jwt from 'jsonwebtoken';
+
+const JWT_ALGORITHM = process.env.JWT_ALGORITHM || 'HS256';
 
 export const authMiddleware = (req, res, next) => {
   // access the token from cookies
@@ -9,40 +11,49 @@ export const authMiddleware = (req, res, next) => {
       .json({ success: false, message: "Token format invalid" });
   }
 
+  if (!process.env.JWT_SECRET) {
+    console.error('JWT_SECRET is not configured');
+    return res.status(500).json({
+      success: false,
+      message: 'Authentication service is misconfigured',
+    });
+  }
+
   try {
     // verify token using jwt key
-    const verify = jwt.verify(token, process.env.JWT_SECRET);
+    const verify = jwt.verify(token, process.env.JWT_SECRET, {
+      algorithms: [JWT_ALGORITHM],
+    });
 
     // attach payload id to request (handle both 'id' and 'userId' for backward compatibility)
     req.userId = verify.id || verify.userId;
     next();
 
   } catch (error) {
-  // error handling
-  console.log("Token verification error", error);
+    // error handling
+    console.log('Token verification error', error);
 
-  // expired token
-  if (error.name === "TokenExpiredError") {
-    return res.status(401).json({
-      success: false,
-      message: "Session expired, please log in again",
-    });
+    // expired token
+    if (error.name === 'TokenExpiredError') {
+      return res.status(401).json({
+        success: false,
+        message: 'Session expired, please log in again',
+      });
 
-  // invalid/tampered token
-  } else if (error.name === "JsonWebTokenError") {
-    return res.status(401).json({
-      success: false,
-      message: "Invalid token",
-    });
+    // invalid/tampered token
+    } else if (error.name === 'JsonWebTokenError') {
+      return res.status(401).json({
+        success: false,
+        message: 'Invalid token',
+      });
 
-  // unexpected server error
-  } else {
-    return res.status(500).json({
-      success: false,
-      message: "Internal server error",
-    });
+    // unexpected server error
+    } else {
+      return res.status(500).json({
+        success: false,
+        message: 'Internal server error',
+      });
+    }
   }
-}
-
-
 };
+


### PR DESCRIPTION
Hardened the auth flow in backend/controllers/authController.js and backend/middlewares/authMiddleware.js. Cookies now use a shared explicit policy with `path: '/'`, `httpOnly`, `secure` in production, `sameSite: 'strict'`, and an optional domain from `AUTH_COOKIE_DOMAIN` or `COOKIE_DOMAIN`. The JWT secret is now required before signing or verifying, and verification is locked to `HS256` by default or whatever `JWT_ALGORITHM` is set to, which closes the algorithm-confusion gap.

Validation passed on the touched files with no parse errors. I also ran the backend lint script; it exited nonzero, but it did not report issues in the two auth files I changed, so the remaining failure appears to be elsewhere in the backend.


closes #856