### PR TITLE
fix(hooks): add error handling to deleteTask and bulkDelete

### DIFF
--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -36,9 +36,17 @@ const useTasks = () => {
 
   // delete task
   const deleteTask = async (id) => {
-    await api.delete(`/tasks/${id}`);
+    // Keep a backup of tasks in case of error
+    const previousTasks = [...tasks];
     // fix : This line refreshes the UI!
     setTasks(prev => prev.filter(t => t._id !== id)); 
+    try {
+      await api.delete(`/tasks/${id}`);
+    } catch (error) {
+      console.log(error?.response?.data?.message || "Failed to delete task");
+      // Rollback on failure
+      setTasks(previousTasks);
+    }
   };
 
   // initial fetch
@@ -48,8 +56,13 @@ const useTasks = () => {
   }, []);
   // bulk delete tasks
   const bulkDelete = async (ids) => {
-    await api.post("/tasks/bulk-delete", { ids });
-    getTasks();
+    try {
+      await api.post("/tasks/bulk-delete", { ids });
+      getTasks();
+    } catch (error) {
+      console.log(error?.response?.data?.message || "Failed to bulk delete tasks");
+      getTasks();
+    }
   };
   // return reusable functions
   return {


### PR DESCRIPTION
### Description
This PR fixes a bug where `deleteTask` and `bulkDelete` in the `useTasks` hook lacked `try/catch` error handling. Previously, if the API call failed, tasks would still be permanently removed from the UI state, causing silent failures.

### Changes Made
- Wrapped `api.delete()` inside `deleteTask` with a `try/catch` block.
- Implemented an optimistic UI update that reverts if the API call fails (task reappears on error).
- Added `try/catch` logic to `bulkDelete` to safely catch and log API failures, followed by an immediate data refetch.

Resolves #880