### PR TITLE
fix(auth): completely clear localStorage on logout to prevent data leaks

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -15,6 +15,8 @@ const AuthProvider = ({ children }) => {
     setUser(null);
     setToken(null);
     localStorage.removeItem("token");
+    localStorage.removeItem("activeRoutineTasks"); // specifically requested in issue #882
+    localStorage.clear(); // Ensure all stale data is wiped
   };
 
   // restore session on app load


### PR DESCRIPTION
### Description
This PR fixes a data leak issue where logging out did not completely wipe `localStorage`. The previous logic left behind the active user's routine tasks and potentially stale tokens, causing them to leak into the dashboard when another user logged in on the same browser.

### Changes Made
- Modified the `logout` function in `AuthContext.jsx`.
- Added `localStorage.removeItem("activeRoutineTasks")`.
- Added `localStorage.clear()` to guarantee all session data is safely purged when the user logs out.

Resolves #882