### PR TITLE
Remove redundant TaskLibrary onAddTask prop

### DIFF
--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -199,12 +199,6 @@ export default function RoutineBuilder() {
   tasks={tasks}
   onAddTask={() => setIsModalOpen(true)}
 />
-            {/*
-             * TaskLibrary's "Add Task" button opens the modal directly
-             * (user is already at the top section of the page, no scroll needed).
-             * Use openModal instead of handleOpenModal here.
-             */}
-            <TaskLibrary onAddTask={openModal} />
           </aside>
 
           <section className="col-span-12 md:col-span-9">


### PR DESCRIPTION
## 📌 Description
Removed the redundant `TaskLibrary` render and deleted the unnecessary commented note in `RoutineBuilder.jsx`.

`TaskLibrary` already handles modal opening internally, so passing `openModal` separately was redundant and could lead to inconsistent modal behavior.

## 🔗 Related Issue
Closes #921 

## 🛠 Changes Made
- Removed duplicate `TaskLibrary` component render
- Deleted unnecessary commented note
- Improved component cleanliness and UI consistency

## 📸 Screenshots (if applicable)
N/A

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
This PR focuses only on removing the redundant `TaskLibrary` usage and related comment without affecting existing functionality.