### PR TITLE
feat: add bulk edit priority and due date for selected tasks

### DIFF
--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -72,6 +72,11 @@ const useTasks = () => {
     await api.post("/tasks/bulk-delete", { ids });
     getTasks();
   };
+  // bulk edit tasks
+  const bulkUpdate = async (ids, updates) => {
+    await Promise.all(ids.map((id) => api.put(`/tasks/${id}`, updates)));
+    await getTasks();
+  };
   // return reusable functions
   return {
     tasks,
@@ -79,6 +84,7 @@ const useTasks = () => {
     updateTask,
     deleteTask,
     bulkDelete,
+    bulkUpdate,
   };
 };
 

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -10,13 +10,15 @@ import EmptyState from "../components/EmptyState";
 
 export default function Tasks() {
   const navigate = useNavigate();
-  const { tasks, addTask, updateTask, deleteTask, bulkDelete } = useTasks();
-
+  const { tasks, addTask, updateTask, deleteTask, bulkDelete, bulkUpdate } = useTasks();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState(null);
   const [taskError, setTaskError] = useState("");
   const [selectedCategories, setSelectedCategories] = useState([]);
   const [selectedIds, setSelectedIds] = useState([]);
+  const [bulkPriority, setBulkPriority] = useState("");
+  const [bulkDueDate, setBulkDueDate] = useState("");
+  const [showBulkEdit, setShowBulkEdit] = useState(false);
 
   const handleSelect = (id) => {
     setSelectedIds((prev) =>
@@ -27,6 +29,17 @@ export default function Tasks() {
   const handleBulkDelete = async () => {
     await bulkDelete(selectedIds);
     setSelectedIds([]);
+  };
+  const handleBulkEdit = async () => {
+    if (!bulkPriority && !bulkDueDate) return;
+    const updates = {};
+    if (bulkPriority) updates.priority = bulkPriority;
+    if (bulkDueDate) updates.dueDate = bulkDueDate;
+    await bulkUpdate(selectedIds, updates);
+    setSelectedIds([]);
+    setBulkPriority("");
+    setBulkDueDate("");
+    setShowBulkEdit(false);
   };
 
   const [durationModalTask, setDurationModalTask] = useState(null);
@@ -148,12 +161,20 @@ const handleActualDurationSubmit = async () => {
 
           <div className="flex items-center gap-3">
             {selectedIds.length > 0 && (
-              <button
-                onClick={handleBulkDelete}
-                className="btn btn-danger flex items-center gap-2 cursor-pointer bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600 transition"
-              >
-                <Trash2 size={18} /> Delete Selected ({selectedIds.length})
-              </button>
+              <div className="flex items-center gap-3 flex-wrap">
+                <button
+                  onClick={() => setShowBulkEdit((prev) => !prev)}
+                  className="flex items-center gap-2 px-4 py-2 rounded-lg border border-primary text-primary hover:bg-primary/10 transition cursor-pointer"
+                >
+                  ✏️ Edit Selected ({selectedIds.length})
+                </button>
+                <button
+                  onClick={handleBulkDelete}
+                  className="btn btn-danger flex items-center gap-2 cursor-pointer bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600 transition"
+                >
+                  <Trash2 size={18} /> Delete Selected ({selectedIds.length})
+                </button>
+              </div>
             )}
             <button
               onClick={() => {
@@ -167,6 +188,45 @@ const handleActualDurationSubmit = async () => {
             </button>
           </div>
         </div>
+        {showBulkEdit && selectedIds.length > 0 && (
+        <div className="card p-4 shadow-sm flex flex-wrap gap-4 items-end animate-in">
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-main">Set Priority</label>
+            <select
+              value={bulkPriority}
+              onChange={(e) => setBulkPriority(e.target.value)}
+              className="p-2 border border-soft rounded-lg bg-transparent text-main dark:bg-slate-800"
+            >
+              <option value="">-- Select --</option>
+              <option value="Low">Low</option>
+              <option value="Medium">Medium</option>
+              <option value="High">High</option>
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-main">Set Due Date</label>
+            <input
+              type="datetime-local"
+              value={bulkDueDate}
+              onChange={(e) => setBulkDueDate(e.target.value)}
+              className="p-2 border border-soft rounded-lg bg-transparent text-main"
+            />
+          </div>
+          <button
+            onClick={handleBulkEdit}
+            disabled={!bulkPriority && !bulkDueDate}
+            className="btn btn-primary px-4 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Apply to {selectedIds.length} Tasks
+          </button>
+          <button
+            onClick={() => setShowBulkEdit(false)}
+            className="px-4 py-2 rounded-lg border border-soft text-muted hover:bg-gray-100 dark:hover:bg-slate-800"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
 
         {/* Category Filter */}
         <div className="animate-in delay-150">


### PR DESCRIPTION
## 📌 Description
Extends the existing multi-select toolbar to support bulk editing of **priority** and **due date** across selected tasks. Previously, multi-select only supported bulk deletion so users had to edit each task individually to update shared fields, which was tedious for larger task lists.

## 🔗 Related Issue
Closes #709

## 🛠 Changes Made
- Added `bulkUpdate(ids, updates)` function in `useTasks.js` that sends parallel `PUT` requests for all selected task IDs and refreshes the task list
- Added `bulkPriority`, `bulkDueDate`, and `showBulkEdit` states in `Tasks.jsx`
- Added **Edit Selected** toggle button alongside the existing Delete Selected button in the bulk action toolbar
- Added an inline bulk edit panel with a priority dropdown (Low / Medium / High) and a datetime picker
- Apply button is disabled until at least one field (priority or due date) is selected
- State resets cleanly after applying or cancelling the bulk edit

## 📸 Screenshots (if applicable)
### "Edit Selected" appearing when tasks are selected :

<img width="1917" height="1025" alt="image" src="https://github.com/user-attachments/assets/9573c436-5f8f-46bd-831f-02ecd45d5794" />

### Badges to *set priority* and *due date* appearing on clicking "Edit Selected" :

<img width="1918" height="1028" alt="image" src="https://github.com/user-attachments/assets/a48b183a-fae7-45e7-a140-ed3356d68579" />

### *set priority* and *due date* changes are reflected and ready to be applied :

<img width="1918" height="1030" alt="image" src="https://github.com/user-attachments/assets/6723c6dd-cd89-4afc-8be0-27931d13495f" />


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
- The `bulkUpdate` function uses `Promise.all` for parallel updates — if any single request fails, the whole batch will reject. Consider whether per-task error handling is needed depending on backend behaviour.
- The edit panel appears inline below the toolbar (no modal) to keep the UX lightweight and consistent with the existing bulk delete pattern.
- Backend endpoint `/tasks/:id` (PUT) is reused as-is — no backend changes were needed.