### PR TITLE
fix: on login and sign up page added dark contrast styling #841

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,7 +64,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2392,7 +2391,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2434,7 +2432,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2565,7 +2562,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2940,7 +2936,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4199,7 +4194,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4293,7 +4287,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4303,7 +4296,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4664,7 +4656,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4868,7 +4859,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -424,7 +424,31 @@ const Login = () => {
               bg-red-500/10
               border-red-500/20
               text-red-500
-              dark:bg-red-900/30
+Suggested Labels:
+bug, frontend, ux, gssoc-approved, good-first-issue
+
+Describe the Bug
+On the user Dashboard page, clicking the "Copy" / "Duplicate" icon button on a saved routine card to clone it immediately redirects the user to the /routine-builder page.
+
+This happens because the parent <li> card element has an onClick navigation handler, and the duplicate <button> nested inside it does not call e.stopPropagation(). The click event bubbles up to the container, causing the page to change instantly, which prevents users from completing the routine duplication flow.
+
+Expected Behavior
+Clicking the duplicate button on the routine card should open the "Duplicate Routine" modal inline on the Dashboard and let the user select a target day without triggering page navigation.
+
+Steps to Reproduce
+Navigate to the Dashboard.
+In the "Saved Routines" panel, locate any saved routine card.
+Click the Copy (Duplicate) icon button in the top-right corner of the routine item.
+Observe that you are immediately redirected to the /routine-builder screen, and the duplicate modal is cut off.
+Target Files/Components
+frontend/src/pages/Dashboard.jsx (around lines 252-258)
+Suggested Fix
+Modify the duplicate button click handler to capture the event and explicitly stop bubbling:
+
+onClick={(e) => {
+  e.stopPropagation();
+  openDuplicateModal(routine);
+}}              dark:bg-red-900/30
               dark:border-red-800
               dark:text-red-300
             "

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -424,6 +424,9 @@ const Login = () => {
               bg-red-500/10
               border-red-500/20
               text-red-500
+              dark:bg-red-900/30
+              dark:border-red-800
+              dark:text-red-300
             "
           >
             {error}

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -292,6 +292,9 @@ const Signup = () => {
                 bg-red-500/10
                 border-red-500/20
                 text-red-500
+                dark:bg-red-900/30
+                dark:border-red-800
+                dark:text-red-300
               "
             >
               {errorMessage}


### PR DESCRIPTION
closes #841

## 📌 Description
Improved the accessibility and readability of error alerts on the Login and Signup pages by adding dark-mode Tailwind variants. This ensures that error messages remain clearly visible and properly styled when the app is used in dark theme.

## 🔗 Related Issue
Closes #<issue_number>

## 🛠 Changes Made
- Added dark-mode styling to the login error alert in `Login.jsx`.
- Added dark-mode styling to the signup error alert in `Signup.jsx`.
- Used Tailwind dark variants for better contrast:
  - `dark:bg-red-900/30`
  - `dark:border-red-800`
  - `dark:text-red-300`
- Ensured the existing light-mode error alert design remains unchanged.
- Checked Login and Signup pages visually after the update.

## 📸 Screenshots (if applicable)
Attached updated screenshots of the Login and Signup pages showing the improved error alert styling.

- Login Page — 
<img width="1770" height="913" alt="image" src="https://github.com/user-attachments/assets/c78daf87-1e72-4ab1-b58f-60049097d14a" />

- Signup Page — 
<img width="1774" height="911" alt="image" src="https://github.com/user-attachments/assets/eebb058a-3353-4d25-aabb-fe305b159f96" />


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Please review the dark-mode error alert styling on both Login and Signup pages.

To verify:
1. Run the frontend locally.
2. Open the Login and Signup pages.
3. Switch to dark mode.
4. Trigger an error alert by submitting invalid or incomplete credentials.
5. Confirm that the alert background, border, and text remain readable in dark theme.

A possible follow-up improvement can be made later to standardize dark-mode styling for other red/error alerts used across the frontend.