### PR TITLE
fix: correct SVG strokeDasharray prop in EmptyState component

### DIFF
--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -31,7 +31,7 @@ const CONFIG = {
     icon: (
       <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ width: 80, height: 80 }}>
         <circle cx="40" cy="40" r="28" stroke="#6366f1" strokeWidth="3" opacity="0.2" />
-        <circle cx="40" cy="40" r="28" stroke="#6366f1" strokeWidth="3" strokeLinedasharray="44 132" strokeLinecap="round" opacity="0.7" />
+        <circle cx="40" cy="40" r="28" stroke="#6366f1" strokeWidth="3" strokeDasharray="44 132" strokeLinecap="round" opacity="0.7" />
         <circle cx="40" cy="40" r="3" fill="#6366f1" />
         <path d="M40 40 V20" stroke="#6366f1" strokeWidth="2.5" strokeLinecap="round" />
         <path d="M40 40 L54 48" stroke="#6366f1" strokeWidth="2" strokeLinecap="round" opacity="0.6" />


### PR DESCRIPTION
## Description
Fixed invalid React SVG prop `strokeLinedasharray` in `frontend/src/components/EmptyState.jsx`.
Replaced it with the correct camelCase prop:
* `strokeDasharray`
This fixes the SVG dash pattern rendering issue in the routines empty state UI.
## Related Issue
Closes #818
## Changes Made
* Corrected invalid SVG prop name
* Updated React SVG syntax
* Fixed dash pattern rendering
## Screenshots (if applicable)
N/A
## Checklist
* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors
* [x] Properly tested changes
* [x] Linked the issue
## Notes for Reviewers
This is a small frontend bug fix correcting the SVG attribute naming in React.