### PR TITLE
bug(frontend): sort upcomingTasks by dueDate and require dueDate field

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -79,7 +79,8 @@ export default function Dashboard() {
     : 0;
 
   const upcomingTasks = tasks
-    .filter((task) => task.status !== "Completed")
+    .filter((task) => task.status !== "Completed" && task.dueDate)
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))
     .slice(0, 2);
 
   // Fetch routines


### PR DESCRIPTION


## 🐛 Fix: Sort upcomingTasks by dueDate and require dueDate field on Dashboard

### 👨‍💻 Program
This contribution is made under **GSSoC 2026**.

---

### 📌 Summary
Fixes the Dashboard "Upcoming Tasks" panel to show the soonest-due tasks
instead of the most recently created tasks.

---

### ❌ Problem
**File:** `frontend/src/pages/Dashboard.jsx` — Lines 81–83
❌ No sort by `dueDate` — shows recently created tasks, not soonest due
❌ No `dueDate` guard — tasks without a due date included
❌ Most urgent tasks may never appear in the panel

---

### ✅ Solution
Added `&& task.dueDate` filter guard and `.sort()` by `dueDate` ascending
before `.slice(0, 2)`.

---

### 📝 Exact Line Change

**File:** `frontend/src/pages/Dashboard.jsx`

```diff
  const upcomingTasks = tasks
-   .filter((task) => task.status !== "Completed")
+   .filter((task) => task.status !== "Completed" && task.dueDate)
+   .sort(\(a, b) => new Date(a.dueDate) - new Date(b.dueDate))
    .slice(0, 2);
```

**Line 82** — add `&& task.dueDate` to the filter  
**Line 82.5** *(new line)* — insert `.sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))` before `.slice(0, 2)`  

---

### 🔄 Before vs After
#### Before: Shows 2 most recently created non-completed tasks
#### After: Shows 2 soonest-due non-completed tasks

---

### 🙌 Contributor Checklist
- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced
------

# Closes #971 
---
