### PR TITLE
fix(backend): add fallback port 5000 when PORT env var is missing

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,7 +10,7 @@ import { routineRouter } from "../routes/routineRoutes.js";
 
 // dotenv config
 dotenv.config({ path: path.resolve(import.meta.dirname, "../.env") });
-const PORT = process.env.PORT;
+const PORT = process.env.PORT|| 5000;
 
 // Initialize express     
 const app = express();


### PR DESCRIPTION
## 🐛 Fix: Add fallback port 5000 in server.js

### 👨‍💻 Program
This contribution is made under **GSSoC 2026**.

---

### 📌 Summary
Adds a default port fallback to `server.js` so the server starts
predictably when `PORT` is not set in the environment.

---

### ❌ Problem
**File:** `backend/src/server.js` — Line 13
❌ `const PORT = process.env.PORT` — no default
❌ Missing env var → `app.listen(undefined)` → random port, no error
❌ Startup log prints `undefined`

---

### ✅ Solution
```js
const PORT = process.env.PORT || 5000;
```

---

### 📝 Exact Line Change

**File:** `backend/src/server.js`

```diff
- const PORT = process.env.PORT;
+ const PORT = process.env.PORT || 5000;
```

**Line 13** — add `|| 5000` fallback

---




### 🔄 Before vs After
#### Before: `Server running at port undefined` (random port, unreachable)
#### After: `Server running at port 5000` (predictable, working default)

---

### 🧪 Testing
- Run without `.env` → binds to port 5000, correct log ✅
- Run with `PORT=3000` in `.env` → still uses 3000 ✅

---

### 🙌 Contributor Checklist
- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] One-line fix, no breaking changes
---
# Closes #979 
---

