### PR TITLE
Fix dropdown visibility in dark mode

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -303,7 +303,7 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
               required
             >
               {priorities.map((p) => (
-                <option key={p} value={p} className="dark:bg-slate-800">
+                <option key={p} value={p} className="bg-white text-black dark:bg-slate-800 dark:text-white">
                   {p}
                 </option>
               ))}


### PR DESCRIPTION
## 📌 Description
Fixed dropdown option visibility issue in dark mode by adding proper text color styling for select options.

## 🔗 Related Issue
Closes #888

## 🛠 Changes Made
- Added dark mode text color for dropdown options
- Improved visibility of select options in dark theme
- Updated option styling for better contrast

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
This fix improves dropdown readability in dark mode by ensuring option text remains visible.