### PR TITLE
fix(auth): enforce password complexity on profile update

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -190,6 +190,15 @@ export const updateProfile = async (req, res) => {
 
     // update password if provided
     if (currentPassword && newPassword) {
+      const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+      if (!passwordRegex.test(newPassword)) {
+        return res.status(400).json({
+          success: false,
+          message:
+            'Password must be at least 8 characters long, include an uppercase letter, a digit, and a special character',
+        });
+      }
+
       // compare current password
       const passwordCheck = await bcrypt.compare(
         currentPassword,


### PR DESCRIPTION
### Description
This PR fixes a security vulnerability where the backend `updateProfile` API completely bypassed the strong password complexity regex that is enforced during signup.

### Changes Made
- Added the standard `passwordRegex` check to `authController.js` inside the `updateProfile` function.
- The API now intercepts any attempts to bypass complexity requirements and returns a `400 Bad Request` with the correct error message before attempting to hash or save the new password.

Resolves <1024>