### PR TITLE
Fix auth cookie SameSite for deployed login

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,7 +4,7 @@ JWT_SECRET=your_super_secret_key_here
 CLIENT_ORIGIN=your_deployed_frontend_url
 FRONTEND_URL=http://localhost:5173
 JWT_EXPIRES_IN=7d
-
+NODE_ENV=production #added for samesite domain setting in production and development environment 
 # Firebase project configuration for backend token verification
 FIREBASE_PROJECT_ID=your_firebase_project_id
 

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -16,11 +16,12 @@ const getJwtSecret = (res) => {
   return process.env.JWT_SECRET;
 };
 
+const isProduction = process.env.NODE_ENV === 'production';
 const getAuthCookieOptions = () => {
   const cookieOptions = {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
+    secure: isProduction,
+    sameSite: isProduction ? 'none' : 'lax',
     path: '/',
     maxAge: AUTH_COOKIE_MAX_AGE,
   };


### PR DESCRIPTION
## 📌 Description
In the ' authcontroller.js ' file , we have sameSite hardcoded as 'strict' for both development and production , for development it works but in production the backend and frontend are in different origins so this stops the '/me' route from receiving a cookie 
as in ' authMiddleware.js ', if(!token) then we return ' Token format invalid ' .

## 🔗 Related Issue
Closes #<934>

## 🛠 Changes Made
- sameSite changed in authcontroller.js to 'none' for production and 'lax' when development
- in backend/.env.example added NODE_ENV=production
- files changed - authcontroller.js and .env.example

## 📸 Screenshots (if applicable)
Before : Response header for /login contained sameSite=strict for production

<img width="1043" height="649" alt="image" src="https://github.com/user-attachments/assets/85cb9247-7321-4059-a527-494f58c1d2e9" />

After : Response header for /login contains sameSite=lax for development

<img width="1919" height="1020" alt="image" src="https://github.com/user-attachments/assets/ab78b173-5f5d-49b4-ac10-b937cee1b94f" />


## ✅ Checklist
- [ X ] Code runs locally
- [ X ] Followed project structure
- [ X ] No console errors
- [ X ] Properly tested changes
- [ X ] Linked the issue

## 🚀 Notes for Reviewers
reviewer kindly verify the changes , tested locally for development.
Could not verify on upstream Render deployment due to no deployment access