### PR TITLE
fix: remove unstable 3D tilt hover animation from auth cards (closes #996)

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useState } from "react";
 import {
   useNavigate,
   Link,
@@ -76,32 +76,7 @@ const LoadingSpinner = () => (
 );
 
 const Login = () => {
-  // Tilt
-  const cardRef = useRef(null);
 
-  const handleMouseMove = (e) => {
-    const card = cardRef.current;
-    if (!card) return;
-
-    const rect = card.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    const centerX = rect.width / 2;
-    const centerY = rect.height / 2;
-    const rotateX = ((y - centerY) / centerY) * -8;
-    const rotateY = ((x - centerX) / centerX) * 8;
-
-    card.style.transition = "transform 0.1s ease-out";
-    card.style.transform = `perspective(1200px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(1.02)`;
-  };
-
-  const handleMouseLeave = () => {
-    const card = cardRef.current;
-    if (!card) return;
-
-    card.style.transition = "transform 0.4s ease-out";
-    card.style.transform = `perspective(1200px) rotateX(0deg) rotateY(0deg) scale(1)`;
-  };
 
   // Auth State
   const [email, setEmail] = useState("");
@@ -232,16 +207,11 @@ const Login = () => {
 
       {/* Card */}
       <div
-        ref={cardRef}
-        onMouseMove={handleMouseMove}
-        onMouseLeave={handleMouseLeave}
         className="
           relative
           z-10
           w-full
           max-w-md
-          will-change-transform
-          transform-gpu
         "
       >
       <form

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -76,8 +76,6 @@ const LoadingSpinner = () => (
 );
 
 const Login = () => {
-
-
   // Auth State
   const [email, setEmail] = useState("");
 

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -60,8 +60,6 @@ const LoadingSpinner = () => (
 );
 
 const Signup = () => {
-
-
   // Auth State
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 import api from "../api/axios";
@@ -60,32 +60,7 @@ const LoadingSpinner = () => (
 );
 
 const Signup = () => {
-  // Tilt
-  const cardRef = useRef(null);
 
-  const handleMouseMove = (e) => {
-    const card = cardRef.current;
-    if (!card) return;
-
-    const rect = card.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    const centerX = rect.width / 2;
-    const centerY = rect.height / 2;
-    const rotateX = ((y - centerY) / centerY) * -8;
-    const rotateY = ((x - centerX) / centerX) * 8;
-
-    card.style.transition = "transform 0.1s ease-out";
-    card.style.transform = `perspective(1200px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(1.02)`;
-  };
-
-  const handleMouseLeave = () => {
-    const card = cardRef.current;
-    if (!card) return;
-
-    card.style.transition = "transform 0.4s ease-out";
-    card.style.transform = `perspective(1200px) rotateX(0deg) rotateY(0deg) scale(1)`;
-  };
 
   // Auth State
   const [name, setName] = useState("");
@@ -196,16 +171,11 @@ const Signup = () => {
 
       {/* Card */}
       <div
-        ref={cardRef}
-        onMouseMove={handleMouseMove}
-        onMouseLeave={handleMouseLeave}
         className="
           relative
           z-10
           w-full
           max-w-md
-          will-change-transform
-          transform-gpu
         "
       >
         <form


### PR DESCRIPTION
## Summary

Resolves #996

The `onMouseMove` / `handleMouseLeave` perspective-transform logic in **Signup.jsx** and **Login.jsx** directly mutated `card.style.transform` at mouse speed, causing visible jitter and visual instability on the auth cards.

## Changes

- **`frontend/src/pages/Signup.jsx`** – removed `cardRef`, `handleMouseMove`, `handleMouseLeave`; removed `ref`, `onMouseMove`, `onMouseLeave`, `will-change-transform`, and `transform-gpu` from the card wrapper div; cleaned up unused `useRef` import.
- **`frontend/src/pages/Login.jsx`** – same removals as above.
- The entry-point `animate-in` CSS transition on the `<form>` is preserved, so the page-load fade-in animation is unaffected.

## Verification

`npm run build` completes successfully (✓ 2227 modules, zero errors).
