### PR TITLE
fix: pull deleted task references from user routines on individual task deletion

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -214,6 +214,18 @@ export const deleteTask = async (req, res) => {
         message: "Task not found",
       });
     }
+
+    await Routine.updateMany(
+      { userId },
+      {
+        $pull: {
+          items: {
+            taskId: taskId,
+          },
+        },
+      }
+    );
+
     return res.status(200).json({
       message: "Task deleted successfully",
     });


### PR DESCRIPTION
### Description
This pull request ensures that when a task is deleted individually via the `deleteTask` controller, its ID reference is removed from all user routines.

### Key Changes
1. Added `Routine.updateMany` inside the `deleteTask` controller function to pull the deleted task ID from the `items` array of all user routines.
2. Kept DB integrity aligned with the behavior in `bulkDeleteTasks`.

Closes #913
