### PR TITLE
fix: shallow copy tasks array before sorting to prevent state mutation in render path

### DIFF
--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -273,7 +273,7 @@ const handleActualDurationSubmit = async () => {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-4 animate-in delay-200">
             {filteredTasks.length ? (
-              filteredTasks
+              [...filteredTasks]
                 .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
                 .map((task) => (
                   <TaskItem


### PR DESCRIPTION
### Description
This pull request resolves a bug where the tasks state array was being mutated directly in the render path of the Tasks page component.

### Key Changes
1. Shallow-copied `filteredTasks` using `[...filteredTasks]` before calling the `.sort()` method, which prevents in-place mutation of the React state array.

Closes #914
