### PR TITLE
fix: sort upcoming tasks by due date

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -80,8 +80,15 @@ export default function Dashboard() {
     : 0;
 
   const upcomingTasks = tasks
-    .filter((task) => task.status !== "Completed")
-    .slice(0, 2);
+  .filter(
+    (task) =>
+      task.status !== "Completed" && task.dueDate
+  )
+  .sort(
+    (a, b) =>
+      new Date(a.dueDate) - new Date(b.dueDate)
+  )
+  .slice(0, 2);
 
   // Fetch routines
   const fetchRoutines = async () => {


### PR DESCRIPTION
## Fix: Upcoming Tasks panel showing incorrect tasks

### Problem

The Upcoming Tasks section on the Dashboard was displaying the most recently created non-completed tasks instead of the tasks with the nearest due dates.

### Root Cause

`upcomingTasks` only filtered completed tasks and directly used `.slice(0, 2)` without:

* filtering tasks without `dueDate`
* sorting tasks by due date

### Changes Made

* Added `dueDate` existence check
* Sorted tasks in ascending order based on nearest due date
* Limited the result to the top 2 upcoming tasks

### Updated Logic

```js
const upcomingTasks = tasks
  .filter(
    (task) =>
      task.status !== "Completed" && task.dueDate
  )
  .sort(
    (a, b) =>
      new Date(a.dueDate) - new Date(b.dueDate)
  )
  .slice(0, 2);
```

### Testing

* Verified completed tasks are excluded
* Verified tasks without due dates are excluded
* Verified nearest due tasks appear first
* Verified only 2 tasks are displayed

### Issue Fixed

Fixes #971

