### PR TITLE
fix: unwanted y-axis scroll removed from Task Form Modal

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -147,10 +147,10 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
   const customTags = tags.filter((t) => !TAGS.includes(t));
 
   return createPortal(
+    <div className="fixed inset-0 z-50">
     <div
-      className="fixed inset-0 z-50 overflow-y-auto
-                 flex flex-col items-center
-                 pt-40 pb-10 px-4
+      className="absolute inset-0 flex items-center justify-center 
+                 py-10 px-4
                  bg-black/20 dark:bg-black/50 backdrop-blur-sm
                  animate-in"
       onMouseDown={(e) => {
@@ -161,7 +161,7 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
     >
       <div
         className="bg-(--surface) rounded-2xl shadow-xl w-full max-w-md p-6
-                   relative border border-soft animate-in delay-100"
+                   relative border border-soft animate-in delay-100 overflow-y-auto max-h-screen"
         onMouseDown={(e) => e.stopPropagation()}
       >
         {/* Close button */}
@@ -351,6 +351,7 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
           </button>
         </form>
       </div>
+    </div>
     </div>,
     document.body
   );


### PR DESCRIPTION
## 📌 Description
This PR fixes unexpected vertical (Y-axis) scrolling behavior in the Task Form Modal, which was affecting the overall Tasks page layout.

## 🔗 Related Issue
Closes #1013 
## 🛠 Changes Made

-  Adjusted vertical padding to prevent layout overflow when the modal is open
-  Refactored flex layout structure to improve containment of modal content
-  Fixed scroll behaviour by controlling overflow-y at the correct container level

## 📸 Screenshots (if applicable)
Before
<img width="1913" height="965" alt="Screenshot 2026-05-22 201759" src="https://github.com/user-attachments/assets/1ca97f4f-2e8a-4c63-8a8c-9965941987bc" />
After
<img width="1913" height="954" alt="Screenshot 2026-05-22 212627" src="https://github.com/user-attachments/assets/9666fada-9744-4e84-9dc4-31566d9d45ac" />

## ✅ Checklist
- [✔️ ] Code runs locally
- [✔️ ] Followed project structure
- [✔️ ] No console errors
- [ ✔️] Properly tested changes
- [✔️ ] Linked the issue

## 🚀 Notes for Reviewers
Please review this PR for the issue #1013 