### PR TITLE
Update hover background color for TaskLibrary component

### DIFF
--- a/frontend/src/components/Routine/TaskLibrary.jsx
+++ b/frontend/src/components/Routine/TaskLibrary.jsx
@@ -29,9 +29,9 @@ function DraggableTask({ task }) {
       style={style}
       {...listeners}
       {...attributes}
-      className="group flex items-center gap-3 rounded-xl border border-soft/50 bg-[#f8fafc]/30 dark:bg-slate-800/40 p-3
-                 cursor-grab active:cursor-grabbing
-                 hover:bg-white dark:hover:bg-slate-850 hover:shadow-md transition duration-200 hover-lift"
+     className="group flex items-center gap-3 rounded-xl border border-soft/50 bg-[#f8fafc]/30 dark:bg-slate-800/40 p-3
+           cursor-grab active:cursor-grabbing
+           hover:bg-white dark:hover:bg-slate-700 hover:shadow-md transition duration-200 hover-lift"
       role="button"
       tabIndex={0}
       aria-label={`${task.title} - Drag to schedule or use arrow keys`}


### PR DESCRIPTION
## 📌 Description
Updates the hover background color for draggable task items in the `TaskLibrary` component. The previous dark mode hover color `slate-850` was a non-standard Tailwind shade that may not render consistently. This PR replaces it with the standard Tailwind color `slate-700` for better visual consistency and a smoother user experience in dark mode.

## 🔗 Related Issue
Closes #1131

## 🛠 Changes Made
- Changed dark mode hover background from `dark:hover:bg-slate-850` to `dark:hover:bg-slate-700`
- Light mode hover behavior remains unchanged (`hover:bg-white`)
- Updated the className string in `DraggableTask` component (line 32)
- Maintained all existing transition effects and hover-lift animations

## 📸 Screenshots (if applicable)
| Mode | Before | After |
|------|--------|-------|
| Dark Mode | `slate-850` (non-standard) | `slate-700` (standard Tailwind) |
| Light Mode | `hover:bg-white` | `hover:bg-white` (unchanged) |

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
- This is a simple styling change affecting only the `TaskLibrary.jsx` component
- Please verify the dark mode hover contrast meets accessibility standards
- The change only affects the `DraggableTask` component inside TaskLibrary
- No functional changes — purely visual/styling update