### PR TITLE
feat: improve drag-and-drop usability on mobile devices (closes #1076)

### DIFF
--- a/frontend/src/components/Routine/TaskLibrary.jsx
+++ b/frontend/src/components/Routine/TaskLibrary.jsx
@@ -29,7 +29,8 @@ function DraggableTask({ task }) {
       style={style}
       {...listeners}
       {...attributes}
-      className="group flex items-center gap-3 rounded-xl border border-soft/50 bg-[#f8fafc]/30 dark:bg-slate-800/40 p-3
+      className="group flex items-center gap-3 rounded-xl border border-soft/50 bg-[#f8fafc]/30 dark:bg-slate-800/40
+                 min-h-[52px] p-3 touch-none
                  cursor-grab active:cursor-grabbing
                  hover:bg-white dark:hover:bg-slate-850 hover:shadow-md transition duration-200 hover-lift"
       role="button"

--- a/frontend/src/components/Routine/WeeklyGrid.jsx
+++ b/frontend/src/components/Routine/WeeklyGrid.jsx
@@ -46,7 +46,7 @@ function DroppableCell({ day, time, tasks, onDeleteTask }) {
   return (
     <div
       ref={setNodeRef}
-      className={`h-full min-h-[3rem] p-1.5 flex flex-col gap-1 transition duration-200 ${
+      className={`h-full min-h-[3.5rem] sm:min-h-[3rem] p-1.5 flex flex-col gap-1 touch-none transition duration-200 ${
         isOver 
           ? "bg-cyan-500/10 dark:bg-cyan-500/20" 
           : "bg-white/40 dark:bg-slate-800/20 hover:bg-white/60 dark:hover:bg-slate-800/30"

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -4,6 +4,7 @@ import {
   DragOverlay,
   KeyboardSensor,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -13,7 +14,7 @@ import TaskFormModal from "../components/Task/TaskFormModal";
 import RoutineCard from "../components/Routine/RoutineCard.jsx";
 import useTasks from "../hooks/useTasks.js";
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Download } from "lucide-react";
+import { ArrowLeft, Download, GripVertical } from "lucide-react";
 import { toPng } from "html-to-image";
 import api from "../api/axios.js";
 import EmptyState from "../components/EmptyState";
@@ -53,9 +54,17 @@ export default function RoutineBuilder() {
 
   const normalizeDay = (day) => String(day || "").trim().toLowerCase();
 
-  // Configure sensors for drag-and-drop (mouse + keyboard)
+  // Configure sensors for drag-and-drop (mouse + touch + keyboard).
+  // TouchSensor: 250 ms hold before drag activates, tolerates 8 px movement so
+  // normal page scroll doesn't accidentally start a drag on mobile.
+  // PointerSensor: 5 px distance threshold prevents jitter on desktop.
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 8 },
+    }),
     useSensor(KeyboardSensor)
   );
 
@@ -332,11 +341,12 @@ export default function RoutineBuilder() {
           </div>
         )}
 
-        {/* Drag Overlay */}
+        {/* Drag Overlay – shown while dragging on desktop and mobile */}
         <DragOverlay dropAnimation={null}>
           {activeTask ? (
-            <div className="rounded-xl bg-white p-3 shadow-xl border border-gray-200">
-              {activeTask.title}
+            <div className="flex items-center gap-2 rounded-xl bg-[#4eb7b3] text-white px-3 py-2 shadow-2xl border border-[#3b8ea0] cursor-grabbing max-w-[200px]">
+              <GripVertical size={14} className="shrink-0 opacity-70" />
+              <span className="text-sm font-medium truncate">{activeTask.title}</span>
             </div>
           ) : null}
         </DragOverlay>


### PR DESCRIPTION
## Summary

Resolves #1076

The `RoutineBuilder` planner's drag-and-drop was built exclusively around `PointerSensor`, which causes two major issues on touch devices:
1. Normal page scrolling accidentally activates drags.
2. Task items and drop zones are too small for reliable thumb targeting.

## Changes

### `frontend/src/pages/RoutineBuilder.jsx`
- **Added `TouchSensor`** from `@dnd-kit/core` with `activationConstraint: { delay: 250, tolerance: 8 }`.  
  The 250 ms hold-delay means a quick swipe-to-scroll is never mistaken for a drag. The 8 px tolerance allows slight finger movement without cancelling the gesture.
- **Added distance constraint to `PointerSensor`** (`distance: 5`) to prevent jitter-triggered drags on desktop.
- **Upgraded `DragOverlay`** from a plain white box to a branded teal card with a `GripVertical` icon, giving users clear visual feedback that a drag is in progress on any device.

### `frontend/src/components/Routine/TaskLibrary.jsx`
- Added **`touch-none`** to `DraggableTask` so the browser does not intercept touch events for scrolling while a drag is being initiated.
- Added **`min-h-[52px]`** to meet the 48 dp minimum touch-target guideline (Material Design / WCAG 2.5.8).

### `frontend/src/components/Routine/WeeklyGrid.jsx`
- Increased `DroppableCell` height to **`min-h-[3.5rem]`** on mobile (`sm:min-h-[3rem]` on desktop) so thumbs can land in the drop zone without pixel-perfect precision.
- Added **`touch-none`** to prevent scroll interference while a dragged item is hovering over a cell.

## Verification

`npm run build` completes successfully (✓ 2227 modules, zero errors).
