### PR TITLE
fix: make scroll-to-top button icon visible in all themes (closes #997)

### DIFF
--- a/frontend/src/components/ScrollToTop.jsx
+++ b/frontend/src/components/ScrollToTop.jsx
@@ -52,7 +52,7 @@ const ScrollToTop = () => {
       {shouldShow && (
         <button
           onClick={scrollToTop}
-          className="p-3 rounded-full bg-[var(--text-main)] text-white shadow-lg hover:bg-[var(--primary)] transition-all duration-300 transform hover:scale-110 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:ring-offset-2"
+          className="p-3 rounded-full bg-[var(--primary)] text-white shadow-lg hover:bg-[var(--primary-hover)] transition-all duration-300 transform hover:scale-110 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:ring-offset-2"
           aria-label="Scroll to top"
         >
           <ArrowUp size={24} />


### PR DESCRIPTION
## Summary

Resolves #997 

This PR fixes the visibility issue with the scroll-to-top button icon, which was previously invisible or blending with the background in default state, particularly in dark mode.

## Changes
- Changed the background color class of the button from `bg-[var(--text-main)]` to `bg-[var(--primary)]` in `ScrollToTop.jsx`.
- This ensures the white arrow icon contrasts well with the background in both light and dark themes, making it clearly identifiable.

## Verification
- Confirmed the button icon is visible before and during hover.
- Tested against both light and dark color schemes.
