### PR TITLE
feat: add toast notifications for routine and task actions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import NotFound from "./pages/NotFound.jsx";
 import About from "./pages/About.jsx";
 import Profile from './pages/Profile.jsx';
 import ScrollToTop from "./components/ScrollToTop.jsx";
+import { ToastProvider } from "./context/ToastContext.jsx";
 
 const AuthLayout = ({ children }) => (
   <div className="min-h-[calc(100vh-3.75rem)] flex items-center justify-center px-4">
@@ -24,6 +25,7 @@ const AuthLayout = ({ children }) => (
 const App = () => {
   return (
     <BrowserRouter>
+      <ToastProvider>
       <Navbar />
       <main className="app-bg min-h-screen pt-15 flex flex-col">
         <Routes>
@@ -76,6 +78,7 @@ const App = () => {
       </main>
       <Footer />
       <ScrollToTop />
+      </ToastProvider>
     </BrowserRouter>
     
   );

--- a/frontend/src/components/Routine/RoutineCard.jsx
+++ b/frontend/src/components/Routine/RoutineCard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { MoreVertical, Trash2 } from "lucide-react";
 import RoutineOverviewModal from "./RoutineOverviewModal";
 import api from "../../api/axios.js";
+import { useToast } from "../../context/ToastContext";
 
 export default function RoutineCard({
   routine,
@@ -11,10 +12,9 @@ export default function RoutineCard({
   fetchRoutines,
 }) {
 
+  const { showToast } = useToast();
   const [isOpen, setIsOpen] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
-  const [showToast, setShowToast] = useState(false);
-  const [showOverlapError, setShowOverlapError] = useState(false);
 
   const menuRef = useRef(null);
 
@@ -104,14 +104,8 @@ export default function RoutineCard({
  const handleStartRoutine = () => {
 
   if (hasOverlap()) {
-
-  setShowOverlapError(true);
-
-  setTimeout(() => {
-    setShowOverlapError(false);
-  }, 3000);
-
-  return;
+    showToast("This routine conflicts with another active routine.", "error");
+    return;
   }
 
   setActiveRoutine((prev) => [
@@ -160,11 +154,7 @@ export default function RoutineCard({
     ])
   );
 
-  setShowToast(true);
-
-  setTimeout(() => {
-    setShowToast(false);
-  }, 3000);
+  showToast("Routine started — tasks added to today's workflow.");
 };
 
  
@@ -226,56 +216,12 @@ export default function RoutineCard({
   } catch (err) {
 
     console.error(err);
-    alert("Failed to delete routine");
+    showToast("Failed to delete routine", "error");
   }
  };
 
   return (
     <>
-{showOverlapError && (
-  <div className="fixed top-6 left-1/2 -translate-x-1/2 z-[100] animate-in slide-in-from-top duration-300">
-
-    <div className="rounded-2xl border border-red-500/20 bg-red-500 text-white shadow-2xl px-5 py-4 min-w-[320px]">
-
-      <p className="text-sm font-semibold">
-        Routine Overlap Detected
-      </p>
-
-      <p className="text-xs mt-1 text-white/80">
-        This routine conflicts with another active routine.
-      </p>
-
-    </div>
-
-  </div>
-)}
-      {/* Success Toast */}
-      {showToast && (
-        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-[100] animate-in slide-in-from-top duration-300">
-
-          <div className="rounded-2xl border border-soft bg-white dark:bg-[#1e293b] shadow-2xl px-5 py-4 min-w-[320px]">
-
-            <div className="flex items-start gap-3">
-
-              <div className="mt-1 h-3 w-3 rounded-full bg-green-500" />
-
-              <div>
-                <p className="text-sm font-semibold text-main">
-                  Routine Started
-                </p>
-
-                <p className="text-xs text-muted mt-1">
-                  Tasks were added to today's workflow.
-                </p>
-              </div>
-
-            </div>
-
-          </div>
-
-        </div>
-      )}
-
       {/* Card */}
       <div
         onClick={() => setIsOpen(true)}

--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { TAGS } from "../../utils/tagUtils";
+import { useToast } from "../../context/ToastContext";
 
 const priorities = ["Low", "Medium", "High"];
 const DESCRIPTION_MAX_LENGTH = 500;
@@ -10,6 +11,7 @@ const TITLE_MAX_LENGTH = 30;
 const TITLE_WARNING_LENGTH = 25;
 
 export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, onError }) {
+  const { showToast } = useToast();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState([]);
@@ -98,11 +100,13 @@ export default function TaskFormModal({ task, onClose, onSubmit, errorMessage, o
     if (!dueDate) return onError?.("Due date is required");
 
     if (!task && dueDate < todayStr) {
-       return alert("Due date cannot be in the past");
+       showToast("Due date cannot be in the past", "error");
+       return;
     }
 
     if (dueDate > maxDateStr) {
-      return alert("Due date cannot be more than 1 year in the future");
+      showToast("Due date cannot be more than 1 year in the future", "error");
+      return;
     }
 
     onSubmit({

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useState, useCallback } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { CheckCircle, XCircle, Info } from "lucide-react";
+
+const ToastContext = createContext(null);
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}
+
+let toastId = 0;
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+
+  const removeToast = useCallback((id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const showToast = useCallback((message, type = "success", duration = 3000) => {
+    const id = ++toastId;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => removeToast(id), duration);
+  }, [removeToast]);
+
+  const iconMap = {
+    success: <CheckCircle size={18} className="shrink-0" />,
+    error: <XCircle size={18} className="shrink-0" />,
+    info: <Info size={18} className="shrink-0" />,
+  };
+
+  const styles = {
+    success: "bg-green-600 text-white",
+    error: "bg-red-600 text-white",
+    info: "bg-white dark:bg-[#1e293b] text-main border border-soft",
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="fixed top-6 left-1/2 -translate-x-1/2 z-[100] flex flex-col gap-2 w-full max-w-sm pointer-events-none">
+        <AnimatePresence>
+          {toasts.map((toast) => (
+            <motion.div
+              key={toast.id}
+              initial={{ opacity: 0, y: -24, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -24, scale: 0.95 }}
+              transition={{ type: "spring", stiffness: 400, damping: 30 }}
+              onClick={() => removeToast(toast.id)}
+              className={`pointer-events-auto rounded-2xl shadow-2xl px-5 py-4 flex items-start gap-3 cursor-pointer ${styles[toast.type]}`}
+            >
+              {iconMap[toast.type]}
+              <p className="text-sm font-medium">{toast.message}</p>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,6 +1,20 @@
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useContext, useState, useCallback, useRef, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { CheckCircle, XCircle, Info } from "lucide-react";
+
+const VALID_TYPES = ["success", "error", "info"];
+
+const iconMap = {
+  success: <CheckCircle size={18} className="shrink-0" />,
+  error: <XCircle size={18} className="shrink-0" />,
+  info: <Info size={18} className="shrink-0" />,
+};
+
+const styles = {
+  success: "bg-green-600 text-white",
+  error: "bg-red-600 text-white",
+  info: "bg-white dark:bg-[#1e293b] text-main border border-soft",
+};
 
 const ToastContext = createContext(null);
 
@@ -14,28 +28,27 @@ let toastId = 0;
 
 export function ToastProvider({ children }) {
   const [toasts, setToasts] = useState([]);
+  const timeoutsRef = useRef({});
 
   const removeToast = useCallback((id) => {
+    clearTimeout(timeoutsRef.current[id]);
+    delete timeoutsRef.current[id];
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
   const showToast = useCallback((message, type = "success", duration = 3000) => {
+    const safeType = VALID_TYPES.includes(type) ? type : "info";
     const id = ++toastId;
-    setToasts((prev) => [...prev, { id, message, type }]);
-    setTimeout(() => removeToast(id), duration);
+    setToasts((prev) => [...prev, { id, message, type: safeType }]);
+    timeoutsRef.current[id] = setTimeout(() => removeToast(id), duration);
   }, [removeToast]);
 
-  const iconMap = {
-    success: <CheckCircle size={18} className="shrink-0" />,
-    error: <XCircle size={18} className="shrink-0" />,
-    info: <Info size={18} className="shrink-0" />,
-  };
-
-  const styles = {
-    success: "bg-green-600 text-white",
-    error: "bg-red-600 text-white",
-    info: "bg-white dark:bg-[#1e293b] text-main border border-soft",
-  };
+  useEffect(() => {
+    return () => {
+      Object.values(timeoutsRef.current).forEach(clearTimeout);
+      timeoutsRef.current = {};
+    };
+  }, []);
 
   return (
     <ToastContext.Provider value={{ showToast }}>

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import api from "../api/axios";
+import { useToast } from "../context/ToastContext";
 
 const useTasks = () => {
+  const { showToast } = useToast();
   const [tasks, setTasks] = useState([]);
 
   // fetch tasks from database
@@ -10,36 +12,20 @@ const useTasks = () => {
       const tasks = await api.get("/tasks");
       setTasks(tasks.data.tasks);
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to load tasks");
+      showToast(error?.response?.data?.message || "Failed to load tasks", "error");
     }
   };
 
   // create new task
   const addTask = async (taskData) => {
-  try {
-    const response = await api.post("/tasks", taskData);
-
-    console.log("Task added:", response.data);
-
-    // instantly update UI
-    setTasks((prev) => [response.data.newTask, ...prev]);
-
-  } catch (error) {
-
-    console.log("FULL ERROR:", error);
-
-    console.log(
-      error?.response?.data?.message ||
-      error?.response?.data ||
-      error.message
-    );
-
-    alert(
-      error?.response?.data?.message ||
-      "Failed to create task"
-    );
-  }
-};
+    try {
+      const response = await api.post("/tasks", taskData);
+      setTasks((prev) => [response.data.newTask, ...prev]);
+      showToast("Task created successfully");
+    } catch (error) {
+      showToast(error?.response?.data?.message || "Failed to create task", "error");
+    }
+  };
 
   // update task
   const updateTask = async (id, updates) => {
@@ -49,17 +35,22 @@ const useTasks = () => {
     try {
       await api.put(`/tasks/${id}`, updates);
       await getTasks();
+      showToast("Task updated successfully");
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to update task");
+      showToast(error?.response?.data?.message || "Failed to update task", "error");
       await getTasks();
     }
   };
 
   // delete task
   const deleteTask = async (id) => {
-    await api.delete(`/tasks/${id}`);
-    // fix : This line refreshes the UI!
-    setTasks(prev => prev.filter(t => t._id !== id)); 
+    try {
+      await api.delete(`/tasks/${id}`);
+      setTasks(prev => prev.filter(t => t._id !== id));
+      showToast("Task deleted successfully");
+    } catch (error) {
+      showToast(error?.response?.data?.message || "Failed to delete task", "error");
+    }
   };
 
   // initial fetch
@@ -67,16 +58,29 @@ const useTasks = () => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     getTasks();
   }, []);
+
   // bulk delete tasks
   const bulkDelete = async (ids) => {
-    await api.post("/tasks/bulk-delete", { ids });
-    getTasks();
+    try {
+      await api.post("/tasks/bulk-delete", { ids });
+      getTasks();
+      showToast(`${ids.length} task(s) deleted successfully`);
+    } catch (error) {
+      showToast(error?.response?.data?.message || "Failed to delete tasks", "error");
+    }
   };
+
   // bulk edit tasks
   const bulkUpdate = async (ids, updates) => {
-    await Promise.all(ids.map((id) => api.put(`/tasks/${id}`, updates)));
-    await getTasks();
+    try {
+      await Promise.all(ids.map((id) => api.put(`/tasks/${id}`, updates)));
+      await getTasks();
+      showToast(`${ids.length} task(s) updated successfully`);
+    } catch (error) {
+      showToast(error?.response?.data?.message || "Failed to update tasks", "error");
+    }
   };
+
   // return reusable functions
   return {
     tasks,

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -63,7 +63,7 @@ const useTasks = () => {
   const bulkDelete = async (ids) => {
     try {
       await api.post("/tasks/bulk-delete", { ids });
-      getTasks();
+      await getTasks();
       showToast(`${ids.length} task(s) deleted successfully`);
     } catch (error) {
       showToast(error?.response?.data?.message || "Failed to delete tasks", "error");

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { useToast } from "../context/ToastContext";
 import {
   ArrowLeft,
   Flame,
@@ -19,6 +20,7 @@ import html2canvas from "html2canvas";
 
 export default function Analytics() {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -117,7 +119,7 @@ export default function Analytics() {
       document.body.removeChild(link);
     } catch (err) {
       console.error("Failed to export image:", err);
-      alert("Failed to export dashboard as image");
+      showToast("Failed to export dashboard as image", "error");
     }
   };
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -14,10 +14,12 @@ import useTasks from "../hooks/useTasks.js";
 import useMixedTasks from "../hooks/useMixedTasks.js";
 import { getGreeting } from "../utils/getGreeting";
 import { DAYS_OF_WEEK } from "../utils/constants";
+import { useToast } from "../context/ToastContext";
 
 export default function Dashboard() {
   const { user } = useContext(AuthContext);
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   const [savedRoutines, setSavedRoutines] = useState([]);
   const [loadingRoutines, setLoadingRoutines] = useState(false);
@@ -132,9 +134,10 @@ const handleDuplicateRoutine = async () => {
     }
 
     closeDuplicateModal();
+    showToast("Routine duplicated successfully");
   } catch (err) {
     console.error(err);
-    alert("Failed to duplicate routine");
+    showToast("Failed to duplicate routine", "error");
   } finally {
     setDuplicatingRoutineId(null);
   }

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,10 +1,12 @@
 import { useContext, useState } from 'react';
 import { AuthContext } from '../context/AuthContext';
 import api from '../api/axios';
+import { useToast } from '../context/ToastContext';
 
 const Profile = () => {
   // auth context
   const { user, setUser } = useContext(AuthContext);
+  const { showToast } = useToast();
 
   // states
   const [name, setName] = useState(user?.name || '');
@@ -23,9 +25,9 @@ const Profile = () => {
       // update user in context
       setUser(res.data.user);
 
-      alert(res.data.message);
+      showToast(res.data.message);
     } catch (error) {
-      alert(error.response?.data?.message || 'Failed to update name');
+      showToast(error.response?.data?.message || 'Failed to update name', 'error');
     }
   };
 
@@ -39,13 +41,13 @@ const Profile = () => {
         newPassword,
       });
 
-      alert(res.data.message);
+      showToast(res.data.message);
 
       // clear password fields
       setCurrentPassword('');
       setNewPassword('');
     } catch (error) {
-      alert(error.response?.data?.message || 'Failed to update password');
+      showToast(error.response?.data?.message || 'Failed to update password', 'error');
     }
   };
 

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -18,10 +18,12 @@ import { toPng } from "html-to-image";
 import api from "../api/axios.js";
 import EmptyState from "../components/EmptyState";
 import { useScrollThenOpen } from "../hooks/useScrollThenOpen.js";
+import { useToast } from "../context/ToastContext";
 
 export default function RoutineBuilder() {
   const { addTask, tasks } = useTasks();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [scheduledTasks, setScheduledTasks] = useState([]);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
@@ -47,7 +49,7 @@ export default function RoutineBuilder() {
       document.body.removeChild(link);
     } catch (error) {
       console.error("Export failed:", error);
-      alert("Failed to export routine as image.");
+      showToast("Failed to export routine as image.", "error");
     }
   };
 
@@ -71,7 +73,7 @@ export default function RoutineBuilder() {
       closeModal();
     } catch (err) {
       console.error(err);
-      alert("Failed to add task");
+      showToast("Failed to add task", "error");
     }
   };
 
@@ -134,19 +136,19 @@ export default function RoutineBuilder() {
       setRoutineName("");
       setDescription("");
       setSelectedDay(null);
-      alert("Routine saved successfully");
+      showToast("Routine saved successfully");
       await fetchRoutines();
     } catch (err) {
       console.error(err);
       const errorMessage = err.response?.data?.message || "Failed to save routine";
-      alert(errorMessage);
+      showToast(errorMessage, "error");
     }
   };
 
   const openSaveRoutineModal = (day) => {
     const hasTasks = scheduledTasks.some((t) => t.day === day);
     if (!hasTasks) {
-      alert(`No tasks scheduled for ${day}`);
+      showToast(`No tasks scheduled for ${day}`, "info");
       return;
     }
     setSelectedDay(day);

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -7,10 +7,12 @@ import { Plus, ArrowLeft, Filter, Trash2 } from "lucide-react";
 import { CATEGORIES } from "../utils/categoryUtils";
 import { getCategoryColor } from "../utils/categoryUtils";
 import EmptyState from "../components/EmptyState";
+import { useToast } from "../context/ToastContext";
 
 export default function Tasks() {
   const navigate = useNavigate();
   const { tasks, addTask, updateTask, deleteTask, bulkDelete, bulkUpdate } = useTasks();
+  const { showToast } = useToast();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState(null);
   const [taskError, setTaskError] = useState("");
@@ -69,7 +71,7 @@ const handleActualDurationSubmit = async () => {
   const durationValue = Number(actualDuration);
 
   if (Number.isNaN(durationValue) || durationValue <= 0) {
-    alert("Please enter a valid duration in minutes");
+    showToast("Please enter a valid duration in minutes", "error");
     return;
   }
 

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import useTasks from "../hooks/useTasks";
 import TaskItem from "../components/Task/TaskItem";
 import TaskFormModal from "../components/Task/TaskFormModal";
@@ -14,7 +14,8 @@ export default function Tasks() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState(null);
   const [taskError, setTaskError] = useState("");
-  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedCategories = searchParams.get("categories")?.split(",").filter(Boolean) || [];
   const [selectedIds, setSelectedIds] = useState([]);
   const [bulkPriority, setBulkPriority] = useState("");
   const [bulkDueDate, setBulkDueDate] = useState("");
@@ -102,11 +103,10 @@ const handleActualDurationSubmit = async () => {
   };
 
   const toggleCategoryFilter = (categoryName) => {
-    setSelectedCategories((prev) =>
-      prev.includes(categoryName)
-        ? prev.filter((cat) => cat !== categoryName)
-        : [...prev, categoryName]
-    );
+    const next = selectedCategories.includes(categoryName)
+      ? selectedCategories.filter((cat) => cat !== categoryName)
+      : [...selectedCategories, categoryName];
+    setSearchParams(next.length > 0 ? { categories: next.join(",") } : {});
   };
 
   const filteredTasks =
@@ -236,7 +236,7 @@ const handleActualDurationSubmit = async () => {
               <h3 className="text-sm font-semibold text-main">Filter by Category</h3>
               {selectedCategories.length > 0 && (
                 <button
-                  onClick={() => setSelectedCategories([])}
+                  onClick={() => setSearchParams({})}
                   className="ml-auto text-xs text-primary hover:underline cursor-pointer"
                 >
                   Clear all

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -108,7 +108,13 @@ const handleActualDurationSubmit = async () => {
     const next = selectedCategories.includes(categoryName)
       ? selectedCategories.filter((cat) => cat !== categoryName)
       : [...selectedCategories, categoryName];
-    setSearchParams(next.length > 0 ? { categories: next.join(",") } : {});
+    const params = new URLSearchParams(searchParams);
+    if (next.length > 0) {
+      params.set("categories", next.join(","));
+    } else {
+      params.delete("categories");
+    }
+    setSearchParams(params);
   };
 
   const filteredTasks =
@@ -238,7 +244,11 @@ const handleActualDurationSubmit = async () => {
               <h3 className="text-sm font-semibold text-main">Filter by Category</h3>
               {selectedCategories.length > 0 && (
                 <button
-                  onClick={() => setSearchParams({})}
+                  onClick={() => {
+                    const params = new URLSearchParams(searchParams);
+                    params.delete("categories");
+                    setSearchParams(params);
+                  }}
                   className="ml-auto text-xs text-primary hover:underline cursor-pointer"
                 >
                   Clear all


### PR DESCRIPTION
Closes #1082

**Changes:**
- Created reusable `ToastContext` with framer-motion animated success/error/info toasts
- Wrapped app with `ToastProvider` in App.jsx
- Replaced all `alert()` and inline toast divs with the centralized toast system across 10 files

**Files changed:**
- `context/ToastContext.jsx` — new toast provider with auto-dismiss, stacking, spring animations
- `hooks/useTasks.js` — success/error toasts for create, update, delete, bulk delete, bulk update
- `pages/Tasks.jsx` — duration validation toast
- `pages/RoutineBuilder.jsx` — save/delete/export/add task toasts
- `components/Routine/RoutineCard.jsx` — start/stop/delete toasts, removed old inline toast divs
- `pages/Dashboard.jsx` — duplicate routine toasts
- `components/Task/TaskFormModal.jsx` — date validation toasts
- `pages/Analytics.jsx` — export feedback toast
- `pages/Profile.jsx` — name/password update toasts