### PR TITLE
fix: preserve active task category filters in URL query parameters

### DIFF
--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import useTasks from "../hooks/useTasks";
 import TaskItem from "../components/Task/TaskItem";
 import TaskFormModal from "../components/Task/TaskFormModal";
@@ -14,7 +14,8 @@ export default function Tasks() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState(null);
   const [taskError, setTaskError] = useState("");
-  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedCategories = searchParams.get("categories")?.split(",").filter(Boolean) || [];
   const [selectedIds, setSelectedIds] = useState([]);
   const [bulkPriority, setBulkPriority] = useState("");
   const [bulkDueDate, setBulkDueDate] = useState("");
@@ -102,11 +103,10 @@ const handleActualDurationSubmit = async () => {
   };
 
   const toggleCategoryFilter = (categoryName) => {
-    setSelectedCategories((prev) =>
-      prev.includes(categoryName)
-        ? prev.filter((cat) => cat !== categoryName)
-        : [...prev, categoryName]
-    );
+    const next = selectedCategories.includes(categoryName)
+      ? selectedCategories.filter((cat) => cat !== categoryName)
+      : [...selectedCategories, categoryName];
+    setSearchParams(next.length > 0 ? { categories: next.join(",") } : {});
   };
 
   const filteredTasks =
@@ -236,7 +236,7 @@ const handleActualDurationSubmit = async () => {
               <h3 className="text-sm font-semibold text-main">Filter by Category</h3>
               {selectedCategories.length > 0 && (
                 <button
-                  onClick={() => setSelectedCategories([])}
+                  onClick={() => setSearchParams({})}
                   className="ml-auto text-xs text-primary hover:underline cursor-pointer"
                 >
                   Clear all

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -106,7 +106,13 @@ const handleActualDurationSubmit = async () => {
     const next = selectedCategories.includes(categoryName)
       ? selectedCategories.filter((cat) => cat !== categoryName)
       : [...selectedCategories, categoryName];
-    setSearchParams(next.length > 0 ? { categories: next.join(",") } : {});
+    const params = new URLSearchParams(searchParams);
+    if (next.length > 0) {
+      params.set("categories", next.join(","));
+    } else {
+      params.delete("categories");
+    }
+    setSearchParams(params);
   };
 
   const filteredTasks =
@@ -236,7 +242,11 @@ const handleActualDurationSubmit = async () => {
               <h3 className="text-sm font-semibold text-main">Filter by Category</h3>
               {selectedCategories.length > 0 && (
                 <button
-                  onClick={() => setSearchParams({})}
+                  onClick={() => {
+                    const params = new URLSearchParams(searchParams);
+                    params.delete("categories");
+                    setSearchParams(params);
+                  }}
                   className="ml-auto text-xs text-primary hover:underline cursor-pointer"
                 >
                   Clear all

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -15,7 +15,10 @@ export default function Tasks() {
   const [editingTask, setEditingTask] = useState(null);
   const [taskError, setTaskError] = useState("");
   const [searchParams, setSearchParams] = useSearchParams();
-  const selectedCategories = searchParams.get("categories")?.split(",").filter(Boolean) || [];
+  const selectedCategories =
+    searchParams.getAll("categories").filter(Boolean).length > 0
+      ? searchParams.getAll("categories").filter(Boolean)
+      : searchParams.get("categories")?.split(",").filter(Boolean) || [];
   const [selectedIds, setSelectedIds] = useState([]);
   const [bulkPriority, setBulkPriority] = useState("");
   const [bulkDueDate, setBulkDueDate] = useState("");


### PR DESCRIPTION
Closes #1084

**Changes:**
- Replaced `useState(selectedCategories)` with `useSearchParams` from react-router-dom
- Reads initial filter state from `?categories=Work,Personal` query param on mount
- Merges with existing query params instead of replacing them — other params (pagina­tion, sort, etc.) survive
- Clears only the `categories` key on "Clear all"

**Testing:**
- `npm run build` passes clean
- Filters survive page refresh, navigation, and are shareable