### PR TITLE
fix: handle unhandled promise rejections in useTasks

### DIFF
--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -56,11 +56,24 @@ const useTasks = () => {
   };
 
   // delete task
-  const deleteTask = async (id) => {
+ const deleteTask = async (id) => {
+  try {
     await api.delete(`/tasks/${id}`);
-    // fix : This line refreshes the UI!
-    setTasks(prev => prev.filter(t => t._id !== id)); 
-  };
+
+    // instantly update UI
+    setTasks((prev) =>
+      prev.filter((t) => t._id !== id)
+    );
+
+  } catch (error) {
+    console.error("Failed to delete task:", error);
+
+    alert(
+      error?.response?.data?.message ||
+      "Failed to delete task"
+    );
+  }
+};
 
   // initial fetch
   useEffect(() => {
@@ -68,15 +81,41 @@ const useTasks = () => {
     getTasks();
   }, []);
   // bulk delete tasks
-  const bulkDelete = async (ids) => {
+ const bulkDelete = async (ids) => {
+  try {
     await api.post("/tasks/bulk-delete", { ids });
-    getTasks();
-  };
-  // bulk edit tasks
-  const bulkUpdate = async (ids, updates) => {
-    await Promise.all(ids.map((id) => api.put(`/tasks/${id}`, updates)));
+
     await getTasks();
-  };
+
+  } catch (error) {
+    console.error("Failed to bulk delete tasks:", error);
+
+    alert(
+      error?.response?.data?.message ||
+      "Failed to delete tasks"
+    );
+  }
+};
+  // bulk edit tasks
+const bulkUpdate = async (ids, updates) => {
+  try {
+    await Promise.all(
+      ids.map((id) =>
+        api.put(`/tasks/${id}`, updates)
+      )
+    );
+
+    await getTasks();
+
+  } catch (error) {
+    console.error("Failed to bulk update tasks:", error);
+
+    alert(
+      error?.response?.data?.message ||
+      "Failed to update tasks"
+    );
+  }
+};
   // return reusable functions
   return {
     tasks,


### PR DESCRIPTION
## Description

Added proper error handling for async task operations in `useTasks.js` to prevent unhandled promise rejections during API/network failures.

## Related Issue

Closes #1127

## Changes Made

* Added try-catch handling to `deleteTask`
* Added try-catch handling to `bulkDelete`
* Added try-catch handling to `bulkUpdate`
* Added user-friendly error feedback
* Logged errors for debugging

## Screenshots (if UI changes)

N/A

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My branch follows the naming convention
* [x] I have tested this locally
* [x] Linting passes (`npm run lint` in frontend/)
* [x] No unrelated files were modified
* [x] Screenshots are attached (if UI change)
