### PR TITLE
fix: correct AuthContext destructure in NotFound.jsx (#<issue-number-if-any>)

### DIFF
--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -4,11 +4,11 @@ import { AuthContext } from "../context/AuthContext.jsx";
 
 const NotFound = () => {
   const navigate = useNavigate();
-  const { token } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
 
   // navigate back to Dashboard/ Login if unauthenticated
   const handleGoHome = () => {
-    navigate(token ? "/dashboard" : "/login");
+    navigate(user ? "/dashboard" : "/login");
   };
 
   return (
@@ -28,7 +28,7 @@ const NotFound = () => {
         onClick={handleGoHome}
         className="btn btn-primary hover-lift cursor-pointer"
       >
-        {token ? "Go to Dashboard" : "Go to Login"}
+        {user ? "Go to Dashboard" : "Go to Login"}
       </button>
     </div>
   );


### PR DESCRIPTION
## What's the bug?
   http://localhost:5173/some-random-page-name
  `NotFound.jsx` destructures `{ token }` from `AuthContext`, but the context
  only exposes `{ user, setUser, logout, isLoading }`. `token` is always
  `undefined`, so the 404 page always shows "Go to Login" and always
  navigates to `/login`, even for authenticated users.

  ## Fix
  Replaced `token` with `user` in both the navigation logic and button label.

  ## Type
  - [x] Bug fix
  - [ ] Feature
  - [ ] Docs

  ## Testing
  - Logged-in user hitting /404 → now sees "Go to Dashboard" and lands correctly
  - Logged-out user hitting /404 → still sees "Go to Login" ✓