### PR TITLE
fix: improve scroll-to-top icon visibility in dark mode

### DIFF
--- a/frontend/src/components/ScrollToTop.jsx
+++ b/frontend/src/components/ScrollToTop.jsx
@@ -52,7 +52,7 @@ const ScrollToTop = () => {
       {shouldShow && (
         <button
           onClick={scrollToTop}
-          className="p-3 rounded-full bg-[var(--text-main)] text-white shadow-lg hover:bg-[var(--primary)] transition-all duration-300 transform hover:scale-110 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:ring-offset-2"
+          className="p-3 rounded-full bg-[var(--text-main)] text-cyan-200 shadow-lg hover:bg-[var(--primary)] hover:text-white transition-all duration-300 transform hover:scale-110 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:ring-offset-2"
           aria-label="Scroll to top"
         >
           <ArrowUp size={24} />


### PR DESCRIPTION
## 📌 Description

Fixed the visibility issue of the scroll-to-top button icon in dark mode by improving the icon contrast.

## 🔗 Related Issue

Closes #997

## 🛠 Changes Made

* Updated scroll-to-top arrow icon color
* Improved icon visibility in dark mode
* Maintained hover state styling consistency