### PR TITLE
Fix routine save/duplicate flow and backend validation

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -16,7 +16,7 @@ export const createRoutine = async (req, res) => {
 
     // fetch routine details from request body
     const { name, description, items } = req.body;
-    if (!name || items.length == 0 || !items) {
+    if (!name || !Array.isArray(items) || items.length === 0) {
       return res
         .status(400)
         .json({ success: false, message: "Please enter required details" });

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -127,11 +127,13 @@ const handleDuplicateRoutine = async () => {
       { targetDay: duplicateTargetDay }
     );
 
+    const duplicatedRoutine = res.data.routine || res.data.routines?.[0];
+
     // Optimistic UI update
-    if (res.data.routine) {
+    if (duplicatedRoutine) {
       setSavedRoutines((prevRoutines) => [
-        res.data.routine,
-        ...prevRoutines,
+        duplicatedRoutine,
+        ...prevRoutines.filter((routine) => routine._id !== duplicatedRoutine._id),
       ]);
     } else {
       await fetchRoutines();

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -124,11 +124,19 @@ export default function RoutineBuilder() {
       }));
 
     try {
-      await api.post("/routines", {
+      const res = await api.post("/routines", {
         name: routineName,
         description,
         items,
       });
+
+      const createdRoutine = res.data.routine || res.data.routines?.[0];
+      if (createdRoutine) {
+        setSavedRoutines((prevRoutines) => [
+          createdRoutine,
+          ...prevRoutines.filter((routine) => routine._id !== createdRoutine._id),
+        ]);
+      }
 
       setIsSaveModalOpen(false);
       setRoutineName("");


### PR DESCRIPTION
## 📌 Description
Fixed the routine save and duplicate flow so the frontend correctly handles the API response shape and displays newly created routines immediately. Also fixed backend validation in routine creation to safely check [items](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron browser/workbench/workbench.html) 
before reading its length, preventing crashes on invalid requests.

## 🔗 Related Issue
Closes #1220 

## 🛠 Changes Made
Normalized routine save/duplicate response handling in the frontend.
Updated routine creation to safely validate [items](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) before using [length](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Added immediate local state updates so new routines appear without waiting for a refetch.

## 📸 Screenshots (if applicable)
NA
## ✅ Checklist
- [ x] Code runs locally
- [ x] Followed project structure
- [x] No console errors
- [x ] Properly tested changes
- [ x] Linked the issue

## 🚀 Notes for Reviewers
Please review the routine save and duplicate flows, especially the API response handling and the backend validation for routine creation.