### PR TITLE
feat: Add Loading Skeleton UI to Dashboard Components

### DIFF
--- a/frontend/src/components/Dashboard/SkeletonLoader.jsx
+++ b/frontend/src/components/Dashboard/SkeletonLoader.jsx
@@ -1,0 +1,103 @@
+/**
+ * SkeletonLoader - Reusable shimmer/pulse skeleton UI for Dashboard sections.
+ * Prevents layout shifts and improves perceived performance while data loads.
+ */
+
+// Base skeleton block with pulse animation
+const SkeletonBlock = ({ className = "" }) => (
+  <div
+    className={`animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700 ${className}`}
+  />
+);
+
+// Skeleton for StatCard components
+export const StatCardSkeleton = () => (
+  <div className="card flex flex-col gap-3 p-5">
+    <div className="flex items-center justify-between">
+      <SkeletonBlock className="h-4 w-20" />
+      <SkeletonBlock className="h-9 w-9 rounded-xl" />
+    </div>
+    <SkeletonBlock className="h-8 w-16 rounded-lg" />
+    <SkeletonBlock className="h-3 w-28 rounded-md" />
+  </div>
+);
+
+// Skeleton for upcoming task preview items
+export const TaskPreviewSkeleton = () => (
+  <div className="card flex flex-col gap-3 p-5">
+    <SkeletonBlock className="mb-2 h-5 w-36 rounded-md" />
+    {[1, 2].map((i) => (
+      <div
+        key={i}
+        className="flex items-center gap-3 rounded-xl border border-slate-100 bg-white/60 p-4 dark:border-slate-700 dark:bg-slate-800/60"
+      >
+        <SkeletonBlock className="h-10 w-10 flex-shrink-0 rounded-full" />
+        <div className="flex flex-1 flex-col gap-2">
+          <SkeletonBlock className="h-4 w-3/4 rounded-md" />
+          <SkeletonBlock className="h-3 w-1/2 rounded-md" />
+        </div>
+        <SkeletonBlock className="h-6 w-16 flex-shrink-0 rounded-full" />
+      </div>
+    ))}
+  </div>
+);
+
+// Skeleton for the contribution heatmap grid
+export const HeatmapSkeleton = () => (
+  <div className="card p-5">
+    <SkeletonBlock className="mb-4 h-5 w-48 rounded-md" />
+    <div className="overflow-x-auto">
+      <div className="flex gap-[3px]">
+        {Array.from({ length: 53 }).map((_, colIdx) => (
+          <div key={colIdx} className="flex flex-col gap-[3px]">
+            {Array.from({ length: 7 }).map((_, rowIdx) => (
+              <SkeletonBlock key={rowIdx} className="h-3 w-3 rounded-sm" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+// Skeleton for saved routine list items
+export const RoutineListSkeleton = () => (
+  <div className="space-y-3">
+    {[1, 2, 3].map((i) => (
+      <div
+        key={i}
+        className="border-l-4 border-slate-200 dark:border-slate-600 rounded-xl p-4 bg-white/80 dark:bg-slate-800/80 shadow-sm"
+      >
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <SkeletonBlock className="h-4 w-36 rounded-md" />
+          <SkeletonBlock className="h-7 w-7 rounded-lg flex-shrink-0" />
+        </div>
+        <SkeletonBlock className="h-3 w-24 rounded-md" />
+      </div>
+    ))}
+  </div>
+);
+
+// Skeleton for the DashboardTasks section
+export const DashboardTasksSkeleton = () => (
+  <div className="card p-5">
+    <SkeletonBlock className="mb-4 h-5 w-32 rounded-md" />
+    <div className="flex flex-col gap-3">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 rounded-xl border border-slate-100 bg-white/60 p-4 dark:border-slate-700 dark:bg-slate-800/60"
+        >
+          <SkeletonBlock className="h-5 w-5 flex-shrink-0 rounded" />
+          <div className="flex flex-1 flex-col gap-2">
+            <SkeletonBlock className="h-4 w-2/3 rounded-md" />
+            <SkeletonBlock className="h-3 w-1/3 rounded-md" />
+          </div>
+          <SkeletonBlock className="h-7 w-20 flex-shrink-0 rounded-full" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default SkeletonBlock;

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -3,14 +3,18 @@ import api from "../api/axios";
 
 const useTasks = () => {
   const [tasks, setTasks] = useState([]);
+  const [loadingTasks, setLoadingTasks] = useState(true);
 
   // fetch tasks from database
   const getTasks = async () => {
     try {
+      setLoadingTasks(true);
       const tasks = await api.get("/tasks");
       setTasks(tasks.data.tasks);
     } catch (error) {
       console.log(error?.response?.data?.message || "Failed to load tasks");
+    } finally {
+      setLoadingTasks(false);
     }
   };
 
@@ -80,6 +84,7 @@ const useTasks = () => {
   // return reusable functions
   return {
     tasks,
+    loadingTasks,
     addTask,
     updateTask,
     deleteTask,

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -8,6 +8,13 @@ import StatCard from "../components/Dashboard/StatCard";
 import TaskPreview from "../components/Dashboard/TaskPreview";
 import DashboardTasks from "../components/Dashboard/DashboardTasks";
 import ContributionHeatmap from "../components/Dashboard/ContributionHeatmap";
+import {
+  StatCardSkeleton,
+  HeatmapSkeleton,
+  DashboardTasksSkeleton,
+  TaskPreviewSkeleton,
+  RoutineListSkeleton,
+} from "../components/Dashboard/SkeletonLoader";
 import api from "../api/axios.js";
 import useTasks from "../hooks/useTasks.js";
 import useMixedTasks from "../hooks/useMixedTasks.js";
@@ -24,7 +31,7 @@ export default function Dashboard() {
   const [routineToDuplicate, setRoutineToDuplicate] = useState(null);
   const [duplicateTargetDay, setDuplicateTargetDay] = useState(DAYS_OF_WEEK[0]);
 
-  const { tasks, updateTask: updateDbTask } = useTasks();
+  const { tasks, loadingTasks, updateTask: updateDbTask } = useTasks();
   const { updateTask, routineTasks } = useMixedTasks(updateDbTask);
   const [showProfilePreview, setShowProfilePreview] = useState(false);
   const [profileImage, setProfileImage] = useState(() => {
@@ -229,44 +236,64 @@ const handleDuplicateRoutine = async () => {
       {/* Stats Row */}
       <section className="flex flex-col lg:flex-row gap-6 w-full">
         <div className="flex-1 animate-in delay-100">
-          <StatCard
-            label="Today"
-            value={`${completedToday} / ${totalToday}`}
-            subtitle="Tasks done"
-            icon={<CheckCircle2 size={20} />}
-          />
+          {loadingTasks ? (
+            <StatCardSkeleton />
+          ) : (
+            <StatCard
+              label="Today"
+              value={`${completedToday} / ${totalToday}`}
+              subtitle="Tasks done"
+              icon={<CheckCircle2 size={20} />}
+            />
+          )}
         </div>
         <div className="flex-1 animate-in delay-200">
-          <StatCard
-            label="This Week"
-            value={`${weeklyCompletionPercent}%`}
-            subtitle="Completion"
-            icon={<Calendar size={20} />}
-          />
+          {loadingTasks ? (
+            <StatCardSkeleton />
+          ) : (
+            <StatCard
+              label="This Week"
+              value={`${weeklyCompletionPercent}%`}
+              subtitle="Completion"
+              icon={<Calendar size={20} />}
+            />
+          )}
         </div>
       </section>
 
       {/* Contribution Heatmap */}
       <div className="w-full animate-in delay-200">
-        <ContributionHeatmap tasks={tasks} routineTasks={routineTasks} />
+        {loadingTasks ? (
+          <HeatmapSkeleton />
+        ) : (
+          <ContributionHeatmap tasks={tasks} routineTasks={routineTasks} />
+        )}
       </div>
 
       {/* Today's Tasks */}
       <div className="w-full animate-in delay-200">
-        <DashboardTasks
-            tasks={[...tasks, ...routineTasks]}
-            updateTask={updateTask}
-        />
+        {loadingTasks ? (
+          <DashboardTasksSkeleton />
+        ) : (
+          <DashboardTasks
+              tasks={[...tasks, ...routineTasks]}
+              updateTask={updateTask}
+          />
+        )}
       </div>
 
       {/* Bottom Row: TaskPreview + Routines */}
       <section className="flex animate-in delay-200 flex-col lg:flex-row gap-6 w-full">
         {/* Upcoming Tasks */}
         <div className="flex-1 animate-in delay-300">
-          <TaskPreview
-            tasks={upcomingTasks}
-            updateTask={updateTask}
-          />
+          {loadingTasks ? (
+            <TaskPreviewSkeleton />
+          ) : (
+            <TaskPreview
+              tasks={upcomingTasks}
+              updateTask={updateTask}
+            />
+          )}
         </div>
 
         {/* Saved Routines */}
@@ -297,7 +324,7 @@ const handleDuplicateRoutine = async () => {
           </div>
 
           {loadingRoutines ? (
-            <p className="text-sm text-muted">Loading routines…</p>
+            <RoutineListSkeleton />
           ) : savedRoutines.length === 0 ? (
             <p className="text-sm text-muted text-center mt-10">
               No routines saved yet


### PR DESCRIPTION
## 📌 Description

Adds shimmer/pulse skeleton loaders to all major Dashboard sections, eliminating layout shifts and improving perceived performance during API data fetch. This is especially impactful given the app is hosted on Render's free tier (30–60s cold starts).

## 🔗 Related Issue

Closes #1240

## 🛠 Changes Made

### New File: \rontend/src/components/Dashboard/SkeletonLoader.jsx\
- \StatCardSkeleton\ — mirrors stat card shape (icon, value, label)
- \HeatmapSkeleton\ — 53×7 grid of pulse cells matching contribution heatmap
- \DashboardTasksSkeleton\ — 3 skeleton task rows with checkbox, title, badge
- \TaskPreviewSkeleton\ — 2 skeleton task items with avatar, title, status pill
- \RoutineListSkeleton\ — 3 skeleton routine entries with border-l accent

### Modified: \rontend/src/hooks/useTasks.js\
- Added \loadingTasks\ boolean state (starts \	rue\, set \alse\ after fetch)
- Exposed via hook return value so Dashboard can react to it

### Modified: \rontend/src/pages/Dashboard.jsx\
- Imported all skeleton components
- Destructured \loadingTasks\ from \useTasks\
- Replaced plain 'Loading routines...' text with \RoutineListSkeleton\
- Conditionally renders skeletons vs real content for all 5 dashboard sections

## 📸 Before / After

| Before | After |
|--------|-------|
| Empty cards / blank screen during load | Animated shimmer placeholders matching content shape |
| Plain text 'Loading routines...' | Skeleton list items with pulse animation |

## ✅ Checklist

- [x] Code runs locally
- [x] Followed existing project structure
- [x] No console errors
- [x] Properly tested skeleton → content transitions
- [x] Full dark mode support (\dark:bg-slate-700\)
- [x] No breaking changes to existing functionality
- [x] Linked the issue

## 🚀 Notes for Reviewers

- All skeleton shapes were designed to match the exact dimensions of the real content to prevent CLS
- The \loadingTasks\ state in \useTasks\ initializes as \	rue\ and flips to \alse\ after the first fetch — no extra API calls
- Both \loadingTasks\ and the existing \loadingRoutines\ gates are now skeleton-aware