### PR TITLE
Fix/update routine whitelist

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -248,7 +248,13 @@ export const updateRoutine = async (req, res) => {
     }
 
     // fetch updated routine details
-    const updates = req.body;
+    const { name, description, items } = req.body;
+
+const updates = {
+  ...(name && { name }),
+  ...(description && { description }),
+  ...(items && { items }),
+};
     const routineId = req.params.id;
 
     if (updates.items) {

--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -42,7 +42,9 @@ export const createRoutine = async (req, res) => {
         });
       }
 
-      const endTime = item.startTime + item.duration;
+      const startTime = Number(item.startTime);
+const duration = Number(item.duration);
+const endTime = startTime + duration;
       formatted.push({
         day: item.day,
         startTime: item.startTime,
@@ -261,7 +263,9 @@ export const updateRoutine = async (req, res) => {
           });
         }
 
-        const endTime = item.startTime + item.duration;
+        const startTime = Number(item.startTime);
+        const duration = Number(item.duration);
+        const endTime = startTime + duration;
         formatted.push({
           day: item.day,
           startTime: item.startTime,


### PR DESCRIPTION
Closes #1208

## Problem

`updateRoutine()` was directly passing `req.body` into MongoDB `$set`, which allowed users to overwrite protected/internal fields such as `userId`.

```js
const updates = req.body;
```

This creates a security risk because attackers could inject unintended fields into the update payload.

## Fix

Implemented field whitelisting by explicitly allowing only:

* `name`
* `description`
* `items`

to be included in the update object before calling `findOneAndUpdate()`.

## Changes Made

Updated:

* `backend/controllers/routineController.js`

Replaced unrestricted request body usage with a safe whitelist-based update object.

## Result

Prevents unauthorized modification of internal fields while preserving valid routine updates.
