### PR TITLE
feat : same task add on multiple button click

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { TAGS } from "../../utils/tagUtils";
@@ -22,9 +22,11 @@ export default function TaskFormModal({
   const [priority, setPriority] = useState("Low");
   const [dueDate, setDueDate] = useState("");
   const [dueTime, setDueTime] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [showOtherInput, setShowOtherInput] = useState(false);
   const [customTagInput, setCustomTagInput] = useState("");
+  const submitLockRef = useRef(false);
 
   const today = new Date();
   const todayStr =
@@ -96,6 +98,7 @@ export default function TaskFormModal({
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (submitLockRef.current) return;
 
     onError?.("");
 
@@ -117,14 +120,23 @@ export default function TaskFormModal({
       return onError?.("Due date cannot be more than 1 year in the future");
     }
 
-    onSubmit({
-      title: title.trim(),
-      description: description.trim(),
-      tags: tags,
-      priority,
-      status: task ? task.status : "Due",
-      dueDate: `${dueDate}T${dueTime}:00`,
-    });
+    try {
+      submitLockRef.current = true;
+      setIsSubmitting(true);
+      await Promise.resolve(
+        onSubmit({
+          title: title.trim(),
+          description: description.trim(),
+          tags: tags,
+          priority,
+          status: task ? task.status : "Due",
+          dueDate: `${dueDate}T${dueTime}:00`,
+        }),
+      );
+    } finally {
+      submitLockRef.current = false;
+      setIsSubmitting(false);
+    }
   };
 
   const toggleTag = (tagName) => {
@@ -181,6 +193,7 @@ export default function TaskFormModal({
           {/* Close button */}
           <button
             onClick={onClose}
+            disabled={isSubmitting}
             className="absolute top-4 right-4 p-1 rounded-full text-main
                      hover:bg-gray-100 dark:hover:bg-slate-700"
             aria-label="Close modal"
@@ -206,6 +219,7 @@ export default function TaskFormModal({
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
+                disabled={isSubmitting}
                 className="w-full mt-1 p-2 border border-soft rounded-lg
                          focus:ring-(--primary) focus:border-(--primary)
                          bg-transparent text-main"
@@ -234,6 +248,7 @@ export default function TaskFormModal({
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
+                disabled={isSubmitting}
                 className="w-full mt-1 p-2 border border-soft rounded-lg
                          focus:ring-(--primary) focus:border-(--primary)
                          bg-transparent text-main"
@@ -265,6 +280,7 @@ export default function TaskFormModal({
                       key={tag}
                       type="button"
                       onClick={() => toggleTag(tag)}
+                      disabled={isSubmitting}
                       className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
                         isSelected
                           ? "ring-2 ring-offset-1"
@@ -284,12 +300,14 @@ export default function TaskFormModal({
                     type="text"
                     value={customTagInput}
                     onChange={(e) => setCustomTagInput(e.target.value)}
+                    disabled={isSubmitting}
                     className="flex-1 p-2 border border-soft rounded-lg bg-transparent text-main"
                     placeholder="Enter custom tag (e.g., 'Essay')"
                   />
                   <button
                     type="button"
                     onClick={addCustomTag}
+                    disabled={isSubmitting}
                     className="btn btn-primary px-3 py-1.5"
                   >
                     Add
@@ -309,6 +327,7 @@ export default function TaskFormModal({
                       <button
                         type="button"
                         onClick={() => removeTag(ct)}
+                        disabled={isSubmitting}
                         className="text-xs text-red-500 px-1"
                         aria-label={`Remove tag ${ct}`}
                       >
@@ -330,6 +349,7 @@ export default function TaskFormModal({
               <select
                 value={priority}
                 onChange={(e) => setPriority(e.target.value)}
+                disabled={isSubmitting}
                 className="w-full mt-1 p-2 border border-soft rounded-lg
                          focus:ring-(--primary) focus:border-(--primary)
                          bg-transparent text-main dark:bg-slate-800"
@@ -352,6 +372,7 @@ export default function TaskFormModal({
                 min={task ? undefined : todayStr}
                 max={maxDateStr}
                 onChange={(e) => setDueDate(e.target.value)}
+                disabled={isSubmitting}
                 className="w-full mt-1 p-2 border border-soft rounded-lg
                focus:ring-(--primary) focus:border-(--primary)
                bg-transparent text-main"
@@ -366,6 +387,7 @@ export default function TaskFormModal({
                 type="time"
                 value={dueTime}
                 onChange={(e) => setDueTime(e.target.value)}
+                disabled={isSubmitting}
                 className="w-full mt-1 p-2 border border-soft rounded-lg
                focus:ring-(--primary) focus:border-(--primary)
                bg-transparent text-main"
@@ -376,9 +398,16 @@ export default function TaskFormModal({
             {/* Submit Button */}
             <button
               type="submit"
-              className="w-full btn btn-primary py-2 mt-2 hover-lift"
+              disabled={isSubmitting}
+              className="w-full btn btn-primary py-2 mt-2 hover-lift disabled:opacity-60 disabled:cursor-not-allowed"
             >
-              {task ? "Update Task" : "Add Task"}
+              {isSubmitting
+                ? task
+                  ? "Updating..."
+                  : "Adding..."
+                : task
+                  ? "Update Task"
+                  : "Add Task"}
             </button>
           </form>
         </div>


### PR DESCRIPTION
## 📌 Description

Fixed the duplicate task creation issue caused by multiple clicks on the "Add Task" button before the task creation request completed.

The button is now disabled during submission, preventing repeated requests and ensuring only one task is created per action.

## 🔗 Related Issue
Closes #1248 

## 🛠 Changes Made
- Added loading state management for task creation
- Disabled the "Add Task" button while the API request is pending
- Prevented duplicate submissions from rapid multiple clicks
- Added loading feedback during task creation

## ✅ Checklist
- [X] Code runs locally
- [X] Followed project structure
- [X] No console errors
- [X] Properly tested changes
- [X] Linked the issue

## 🚀 Notes for Reviewers
The fix ensures users cannot accidentally create duplicate tasks by clicking the button multiple times during an ongoing request.
