### PR TITLE
Tasklibrary draggable-div text visible

### DIFF
--- a/frontend/src/components/Routine/TaskLibrary.jsx
+++ b/frontend/src/components/Routine/TaskLibrary.jsx
@@ -29,9 +29,11 @@ function DraggableTask({ task }) {
       style={style}
       {...listeners}
       {...attributes}
-      className="group flex items-center gap-3 rounded-xl border border-soft/50 bg-[#f8fafc]/30 dark:bg-slate-800/40 p-3
-                 cursor-grab active:cursor-grabbing
-                 hover:bg-white dark:hover:bg-slate-850 hover:shadow-md transition duration-200 hover-lift"
+      className="group flex items-center gap-3 rounded-xl border border-slate-200/60 dark:border-slate-700/60
+bg-slate-50/60 dark:bg-slate-800/60 p-3
+cursor-grab active:cursor-grabbing
+hover:bg-white dark:hover:bg-slate-700
+hover:shadow-md transition duration-200 hover-lift"
       role="button"
       tabIndex={0}
       aria-label={`${task.title} - Drag to schedule or use arrow keys`}
@@ -50,7 +52,7 @@ function DraggableTask({ task }) {
       />
 
       {/* Title */}
-      <p className="flex-1 text-sm font-medium text-main truncate">
+      <p className="flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">
         {task.title}
       </p>
     </div>

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -343,7 +343,7 @@ export default function RoutineBuilder() {
         {/* Drag Overlay */}
         <DragOverlay dropAnimation={null}>
           {activeTask ? (
-            <div className="rounded-xl bg-white p-3 shadow-xl border border-gray-200">
+            <div className="rounded-xl bg-white dark:text-black p-3 shadow-xl border border-gray-200">
               {activeTask.title}
             </div>
           ) : null}


### PR DESCRIPTION
## 📌 Description
In the tasklibrary in routineBuilder , the draggable task div text-color was not visible in darkmode

## 🔗 Related Issue
Closes #1113

## 🛠 Changes Made
- Files changed are :
 modified:   frontend/src/components/Routine/TaskLibrary.jsx
 modified:   frontend/src/pages/RoutineBuilder.jsx

## 📸 Screenshots (if applicable)
After : On hovering over the task on tasklibrary div , the text is visible (in the attached images , the component is in hover state)

<img width="1916" height="1037" alt="image" src="https://github.com/user-attachments/assets/e5d6d328-c96b-4020-a01c-e8fc636b5fa2" />

<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/6ec9734d-ee2f-47a7-8a7d-ceee6479962a" />

<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/de0391d3-0a06-41e5-b8bb-5a243c6cb3e8" />

<img width="1915" height="1034" alt="image" src="https://github.com/user-attachments/assets/415812ee-ab86-4e00-a312-6dacea89c2cd" />


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
I think that in Login.jsx instead of /auth/me , /auth/user might be there , because when checking locally login was not working, though any changes related to that are NOT made in this PR.
