### PR TITLE
chore: Add .editorconfig for consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+﻿root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{js,jsx,ts,tsx}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.{css,html}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
﻿## Description
Add a `.editorconfig` file to enforce consistent formatting across all contributors regardless of their editor or IDE.

## Problem Statement
With a full-stack project (React frontend + Node.js backend), contributors using different editors may introduce inconsistent indentation, trailing whitespace, and line endings — creating noisy diffs and slowing down reviews.

## Proposed Solution
Create a `.editorconfig` at the project root:
- `root = true`
- UTF-8 encoding, LF line endings
- 2-space indent for JS/TS/JSX/TSX, JSON, YAML, Markdown, CSS, HTML
- Trim trailing whitespace, insert final newline
- Markdown preserves trailing whitespace (intentional line breaks)

## Acceptance Criteria
- [x] `.editorconfig` exists at project root
- [x] Covers frontend and backend file types
- [x] No changes to existing source files

## GSSoC
- [ ] I am a registered GSSoC 2026 contributor
- [ ] I would like to implement this feature myself
