### PR TITLE
feat: clear scheduled grid after saving a routine

### DIFF
--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -142,6 +142,7 @@ export default function RoutineBuilder() {
       setRoutineName("");
       setDescription("");
       setSelectedDay(null);
+      setScheduledTasks([]);
       alert("Routine saved successfully");
       await fetchRoutines();
     } catch (err) {
@@ -219,13 +220,22 @@ export default function RoutineBuilder() {
               <p className="mt-1 text-muted">Design your week</p>
             </div>
           </div>
-          <button
-            onClick={exportToImage}
-            className="btn btn-primary flex items-center gap-2 cursor-pointer hover-lift"
-          >
-            <Download size={16} />
-            Export as PNG
-          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setScheduledTasks([])}
+              disabled={scheduledTasks.length === 0}
+              className="btn btn-muted cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Clear Grid
+            </button>
+            <button
+              onClick={exportToImage}
+              className="btn btn-primary flex items-center gap-2 cursor-pointer hover-lift"
+            >
+              <Download size={16} />
+              Export as PNG
+            </button>
+          </div>
         </header>
 
         {/* Main Layout */}


### PR DESCRIPTION
## Description
After saving a routine, the weekly grid stayed fully populated with no way to reset it. This PR auto-clears the grid after a successful save and adds a Clear Grid button in the header for manual resets.

## Related Issue
Closes #1174 

## Changes Made
- Added `setScheduledTasks([])` in `confirmSaveRoutine` after a successful save
- Added a Clear Grid button in the page header, disabled when grid is already empty

## Screenshots
UI change is limited to the page header — a "Clear Grid" button 
is added next to "Export as PNG". Button is disabled when no tasks 
are scheduled. Tested locally, login required to access the page.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch follows the naming convention
- [x] I have tested this locally
- [x] Linting passes (`npm run lint` in frontend/)
- [x] No unrelated files were modified

