### PR TITLE
feat: add incomplete tasks badge to Navbar Tasks link

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,6 +4,7 @@ import { Link, NavLink, useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Menu, X, LayoutDashboard, CheckSquare, Calendar, LogOut, LogIn, User, Sun, Moon, TrendingUp } from "lucide-react";
 import { AuthContext } from "../context/AuthContext";
+import useTasks from "../hooks/useTasks";
 import { ThemeContext } from "../context/ThemeContext";
 import gsap from "gsap";
 import { clsx } from "clsx";
@@ -75,6 +76,8 @@ const LogoutModal = ({ isOpen, onConfirm, onCancel }) => (
 const Navbar = () => {
   const { user, logout } = useContext(AuthContext);
   const { theme, toggleTheme } = useContext(ThemeContext);
+  const { tasks } = useTasks();
+  const incompleteTasks = tasks.filter((t) => t.status !== "Completed").length;
   const [isOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const location = useLocation();
@@ -206,7 +209,7 @@ const Navbar = () => {
   // Navigation Links configuration
  const navLinks = [
   { name: "Dashboard", path: "/dashboard", icon: LayoutDashboard },
-  { name: "Tasks", path: "/tasks", icon: CheckSquare },
+  { name: "Tasks", path: "/tasks", icon: CheckSquare, badge: incompleteTasks },
   { name: "Routine Builder", path: "/routine-builder", icon: Calendar },
   { name: "Analytics", path: "/analytics", icon: TrendingUp },
   { name: "Profile", path: "/profile", icon: User },
@@ -253,22 +256,27 @@ const Navbar = () => {
             {user && (
               <div className="hidden md:flex items-center gap-2">
                 {navLinks.map((link) => (
-                  <NavLink
-                    key={link.name}
-                    to={link.path}
-                    className={({ isActive }) =>
-                      cn(
-                        "px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 flex items-center gap-2",
-                        isActive
-                          ? "bg-[#d0f6e3] text-[#3b8ea0] shadow-sm"
-                          : "text-[#4eb7b3] hover:bg-[#d0f6e3]/50 hover:text-[#3b8ea0]"
-                      )
-                    }
-                  >
-                    <link.icon size={16} className={cn("transition-transform duration-200")} />
-                    {link.name}
-                  </NavLink>
-                ))}
+                        <NavLink
+                          key={link.name}
+                          to={link.path}
+                          className={({ isActive }) =>
+                            cn(
+                              "px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 flex items-center gap-2",
+                              isActive
+                                ? "bg-[#d0f6e3] text-[#3b8ea0] shadow-sm"
+                                : "text-[#4eb7b3] hover:bg-[#d0f6e3]/50 hover:text-[#3b8ea0]"
+                            )
+                          }
+                        >
+                          <link.icon size={16} className={cn("transition-transform duration-200")} />
+                          {link.name}
+                          {link.badge > 0 && (
+                            <span className="ml-1 bg-red-500 text-white text-xs px-2 py-0.5 rounded-full leading-none">
+                              {link.badge}
+                            </span>
+                          )}
+                        </NavLink>
+                      ))}
               </div>
             )}
 
@@ -331,23 +339,28 @@ const Navbar = () => {
           >
             <div className="px-4 pt-2 pb-6 space-y-1">
               {user && navLinks.map((link) => (
-                <NavLink
-                  key={link.name}
-                  to={link.path}
-                  onClick={() => setIsOpen(false)}
-                  className={({ isActive }) =>
-                    cn(
-                      "px-4 py-3 rounded-xl text-base font-medium transition-colors flex items-center gap-3 w-full",
-                      isActive
-                        ? "bg-[#d0f6e3] text-[#3b8ea0]"
-                        : "text-[#4eb7b3] hover:bg-[#d0f6e3]/50 hover:text-[#3b8ea0]"
-                    )
-                  }
-                >
-                  <link.icon size={18} />
-                  {link.name}
-                </NavLink>
-              ))}
+                  <NavLink
+                    key={link.name}
+                    to={link.path}
+                    onClick={() => setIsOpen(false)}
+                    className={({ isActive }) =>
+                      cn(
+                        "px-4 py-3 rounded-xl text-base font-medium transition-colors flex items-center gap-3 w-full",
+                        isActive
+                          ? "bg-[#d0f6e3] text-[#3b8ea0]"
+                          : "text-[#4eb7b3] hover:bg-[#d0f6e3]/50 hover:text-[#3b8ea0]"
+                      )
+                    }
+                  >
+                    <link.icon size={18} />
+                    {link.name}
+                    {link.badge > 0 && (
+                      <span className="ml-auto bg-red-500 text-white text-xs px-2 py-0.5 rounded-full leading-none">
+                        {link.badge}
+                      </span>
+                    )}
+                  </NavLink>
+                ))}
 
                 <div className={cn("flex flex-col gap-2", user ? "pt-4 mt-2 border-t border-[#98e1d7]/30" : "pt-2")}>
                   {!user ? (


### PR DESCRIPTION
## 📌 Description
Added a dynamic red notification badge next to the "Tasks" link in the Navbar 
that displays the count of incomplete tasks. The badge updates in real-time 
using the existing `useTasks` hook and is hidden when there are no incomplete 
tasks. The badge is rendered in both the desktop and mobile navigation menus.

## 🔗 Related Issue
Closes #1023 

## 🛠 Changes Made
- Imported `useTasks` hook in `Navbar.jsx`
- Computed `incompleteTasks` count by filtering tasks where `status !== "Completed"`
- Added `badge` property to the Tasks entry in the `navLinks` array
- Rendered a red badge `<span>` next to "Tasks" in the desktop navbar
- Rendered a red badge `<span>` next to "Tasks" in the mobile dropdown navbar
- Badge is conditionally rendered only when `incompleteTasks > 0`

## 📸 Screenshots (if applicable)
Before:
<img width="1909" height="95" alt="image" src="https://github.com/user-attachments/assets/d97f4c63-9c3b-4909-beeb-fd7b542beb96" />
After:
<img width="1904" height="124" alt="image" src="https://github.com/user-attachments/assets/e6412835-9526-4910-9c49-15183ff0bd4d" />


## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
- Only `frontend/src/components/Navbar.jsx` was modified
- No new dependencies were added
- The `useTasks` hook was reused as-is without any modifications
- Badge uses existing Tailwind CSS utility classes consistent with the codebase
- `ml-auto` is used in mobile view to push the badge to the right for better UX
- The count reflects all tasks with status `"Due"` which matches the existing 
  `TASK_STATUS` constants defined in `constants.js`
