### PR TITLE
fix: remove debug console.log statements from useTasks.js and use console.error for error handling

### DIFF
--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -42,7 +42,7 @@ const useTasks = ({
         limit: data.limit || initialLimit,
       });
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to load tasks");
+      console.error(error?.response?.data?.message || "Failed to load tasks");
       setTasks([]);
     }
   }, [initialLimit, page]);
@@ -50,9 +50,7 @@ const useTasks = ({
   // create new task
   const addTask = async (taskData) => {
     try {
-      const response = await api.post("/tasks", taskData);
-
-      console.log("Task added:", response.data);
+      await api.post("/tasks", taskData);
 
       if (page === DEFAULT_PAGE) {
         await getTasks(DEFAULT_PAGE);
@@ -60,10 +58,6 @@ const useTasks = ({
         setPage(DEFAULT_PAGE);
       }
     } catch (error) {
-      console.log("FULL ERROR:", error);
-      console.log(
-        error?.response?.data?.message || error?.response?.data || error.message
-      );
       alert(error?.response?.data?.message || "Failed to create task");
       throw error;
     }
@@ -79,7 +73,7 @@ const useTasks = ({
       await api.put(`/tasks/${id}`, updates);
       await getTasks(page);
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to update task");
+      console.error(error?.response?.data?.message || "Failed to update task");
       await getTasks(page);
     }
   };


### PR DESCRIPTION
## 📌 Description
Removed debug `console.log` statements left behind from development in `useTasks.js` and replaced error logs with the semantically correct `console.error`. Leaving `console.log` in production code leaks internal API response data and full error objects to anyone who opens browser DevTools - a minor but real security and code quality concern.

## 🔗 Related Issue
Closes #1356 

## 🛠 Changes Made
- Removed `console.log("Task added:", response.data)` from `addTask` success path
- Removed `console.log("FULL ERROR:", error)` from `addTask` catch block
- Removed redundant `console.log` of error message from `addTask` catch block
- Removed unused `response` variable assignment in `addTask` since the response data is no longer logged
- Replaced `console.log` with `console.error` in `getTasks` catch block
- Replaced `console.log` with `console.error` in `updateTask` catch block

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Only `useTasks.js` is touched - no logic changes whatsoever.