### PR TITLE
fix: add dark mode classes to drag overlay in RoutineBuilder

### DIFF
--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -343,7 +343,7 @@ export default function RoutineBuilder() {
         {/* Drag Overlay */}
         <DragOverlay dropAnimation={null}>
           {activeTask ? (
-            <div className="rounded-xl bg-white p-3 shadow-xl border border-gray-200">
+            <div className="rounded-xl bg-white dark:bg-slate-800 p-3 shadow-xl border border-gray-200 dark:border-slate-700 text-main">
               {activeTask.title}
             </div>
           ) : null}


### PR DESCRIPTION
## 📌 Description
added dark mode classes to support dark mode in dragoverlay component in `RoutineBuilder.jsx`. Now it solves the visual UI break of `dragOverlay` Component in dark mode.

## 🔗 Related Issue
Closes #1360 

## 🛠 Changes Made
- added `dark:bg-slate-800` class
- added `dark:border-slate-700` class
- added `text-main` class to appear the text visually properly 

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Only few dark variants / classes added in `RoutineBuilder` to support dark mode. in `DragOverlay` . No app logic is changed.
