### PR TITLE
fix: use composite keys for scheduled task lists in WeeklyGrid and RoutineCard to prevent React key warnings

### DIFF
--- a/frontend/src/components/Routine/RoutineCard.jsx
+++ b/frontend/src/components/Routine/RoutineCard.jsx
@@ -208,7 +208,6 @@ export default function RoutineCard({
   const handleDeleteRoutine = async () => {
 
   try {
-    console.log("DELETE CLICKED");
     await api.delete(
       `/routines/${routine._id}`
     );
@@ -321,7 +320,7 @@ export default function RoutineCard({
                       ).padStart(2, "0");
 
                       return (
-                        <li key={task.taskId} className="text-xs text-muted flex items-center gap-1.5 truncate">
+                        <li key={`${task.taskId}-${task.startTime}`} className="text-xs text-muted flex items-center gap-1.5 truncate">
                           <span className="font-semibold text-main/80 shrink-0">{hours}:{minutes}</span>
                           <span className="text-main/50 shrink-0">•</span>
                           <span className="truncate">{task.title}</span>

--- a/frontend/src/components/Routine/WeeklyGrid.jsx
+++ b/frontend/src/components/Routine/WeeklyGrid.jsx
@@ -56,7 +56,7 @@ function DroppableCell({ day, time, tasks, onDeleteTask }) {
     >
       {tasks.map((task) => (
         <div
-          key={task.taskId}
+          key={`${task.day}-${task.startTime}-${task.taskId}`}
           className="group/item relative flex items-center justify-between gap-1.5 rounded-lg bg-[#4eb7b3] text-white text-[10px] sm:text-xs font-medium px-2 py-1 shadow-sm hover:bg-[#3b8ea0] transition-all animate-in"
         >
           <span className="truncate pr-3 leading-tight">{task.title}</span>


### PR DESCRIPTION
## 📌 Description
Fixed unstable React list keys in `WeeklyGrid.jsx` and `RoutineCard.jsx` where `task.taskId` was used as the sole key. Since the same task can be scheduled on multiple days or at different times, `taskId` alone is not guaranteed to be unique within a list -causing React key warnings and potential list rendering bugs. Replaced with composite keys that combine enough fields to guarantee uniqueness. Also removed a stray debug `console.log("DELETE CLICKED")` found in `RoutineCard.jsx`.

## 🔗 Related Issue
Closes #1364 

## 🛠 Changes Made
- `WeeklyGrid.jsx` - changed `key={task.taskId}` to `key={\`${task.day}-${task.startTime}-${task.taskId}\`}` in `DroppableCell`
- `RoutineCard.jsx` - changed `key={task.taskId}` to `key={\`${task.taskId}-${task.startTime}\`}` in the task list inside `tasksByDay`
- `RoutineCard.jsx` - removed stray `console.log("DELETE CLICKED")` from `handleDeleteRoutine`

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Only `WeeklyGrid.jsx` and `RoutineCard.jsx` are touched - no logic changed.