### PR TITLE
fix: remove the flame icon imported from lucide-react but never used

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,7 +2,7 @@ import OnboardingModal from "../components/OnboardingModal";
 import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
-import { CheckCircle2, Calendar, Flame, ArrowRight, RotateCw, Copy } from "lucide-react";
+import { CheckCircle2, Calendar, ArrowRight, RotateCw, Copy } from "lucide-react";
 import LiveClock from "../components/Dashboard/LiveClock";
 import StatCard from "../components/Dashboard/StatCard";
 import TaskPreview from "../components/Dashboard/TaskPreview";


### PR DESCRIPTION
## 📌 Description
Removed the flame icon imported from lucide-react but never used in the `Dashboard.jsx` file.

## 🔗 Related Issue
Closes #1366 

## 🛠 Changes Made
- Remove `Flame` icon from the import from lucide-react 

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Just removed the icon but nothing is touched without this. No logic chnaged.
