### PR TITLE
feat: add Kanban board view for task management

### DIFF
--- a/backend/routes/taskRoutes.js
+++ b/backend/routes/taskRoutes.js
@@ -53,8 +53,8 @@ const taskUpdateValidationRules = [
     .withMessage("Priority must be Low, Medium, or High"),
   body("status")
     .optional()
-    .isIn(["Due", "Completed"])
-    .withMessage("Status must be Due or Completed"),
+    .isIn(["Due", "In Progress", "Completed"])
+    .withMessage("Status must be Due, In Progress, or Completed"),
 ];
 
 // router object for task

--- a/backend/src/models/Task.js
+++ b/backend/src/models/Task.js
@@ -28,7 +28,7 @@ const taskSchema = mongoose.Schema(
     status: {
       type: String,
       required: true,
-      enum: ["Due", "Completed"],
+      enum: ["Due", "In Progress", "Completed"],
     },
     dueDate: {
       type: Date,

--- a/frontend/src/components/Task/KanbanBoard.jsx
+++ b/frontend/src/components/Task/KanbanBoard.jsx
@@ -1,0 +1,53 @@
+import TaskItem from "./TaskItem";
+
+export default function KanbanBoard({
+  tasks,
+  onToggleComplete,
+  onDelete,
+  onEdit,
+  onUpdate,
+  selectedIds,
+  onSelect,
+}) {
+  const dueTasks = tasks.filter((t) => t.status === "Due");
+  const inProgressTasks = tasks.filter((t) => t.status === "In Progress");
+  const completedTasks = tasks.filter((t) => t.status === "Completed");
+
+  const Column = ({ title, columnTasks, status }) => (
+    <div className="flex flex-col bg-gray-50 dark:bg-slate-800/50 rounded-xl p-4 min-h-[500px]">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="font-semibold text-main">{title}</h3>
+        <span className="bg-gray-200 dark:bg-slate-700 text-xs px-2 py-1 rounded-full text-muted">
+          {columnTasks.length}
+        </span>
+      </div>
+      <div className="flex flex-col gap-3">
+        {columnTasks.map((task) => (
+          <TaskItem
+            key={task._id}
+            task={task}
+            onToggleComplete={onToggleComplete}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            onUpdate={onUpdate}
+            isSelected={selectedIds.includes(task._id)}
+            onSelect={onSelect}
+          />
+        ))}
+        {columnTasks.length === 0 && (
+          <div className="text-center text-sm text-muted py-8 border-2 border-dashed border-gray-200 dark:border-slate-700 rounded-lg">
+            No tasks {status.toLowerCase()}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 animate-in w-full">
+      <Column title="Due" columnTasks={dueTasks} status="Due" />
+      <Column title="In Progress" columnTasks={inProgressTasks} status="In Progress" />
+      <Column title="Completed" columnTasks={completedTasks} status="Completed" />
+    </div>
+  );
+}

--- a/frontend/src/components/Task/KanbanBoard.jsx
+++ b/frontend/src/components/Task/KanbanBoard.jsx
@@ -1,5 +1,35 @@
 import TaskItem from "./TaskItem";
 
+const Column = ({ title, columnTasks, status, onToggleComplete, onDelete, onEdit, onUpdate, selectedIds, onSelect }) => (
+  <div className="flex flex-col bg-gray-50 dark:bg-slate-800/50 rounded-xl p-4 min-h-[500px]">
+    <div className="flex items-center justify-between mb-4">
+      <h3 className="font-semibold text-main">{title}</h3>
+      <span className="bg-gray-200 dark:bg-slate-700 text-xs px-2 py-1 rounded-full text-muted">
+        {columnTasks.length}
+      </span>
+    </div>
+    <div className="flex flex-col gap-3">
+      {columnTasks.map((task) => (
+        <TaskItem
+          key={task._id}
+          task={task}
+          onToggleComplete={onToggleComplete}
+          onDelete={onDelete}
+          onEdit={onEdit}
+          onUpdate={onUpdate}
+          isSelected={selectedIds.includes(task._id)}
+          onSelect={onSelect}
+        />
+      ))}
+      {columnTasks.length === 0 && (
+        <div className="text-center text-sm text-muted py-8 border-2 border-dashed border-gray-200 dark:border-slate-700 rounded-lg">
+          No tasks {status.toLowerCase()}
+        </div>
+      )}
+    </div>
+  </div>
+);
+
 export default function KanbanBoard({
   tasks,
   onToggleComplete,
@@ -13,41 +43,20 @@ export default function KanbanBoard({
   const inProgressTasks = tasks.filter((t) => t.status === "In Progress");
   const completedTasks = tasks.filter((t) => t.status === "Completed");
 
-  const Column = ({ title, columnTasks, status }) => (
-    <div className="flex flex-col bg-gray-50 dark:bg-slate-800/50 rounded-xl p-4 min-h-[500px]">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="font-semibold text-main">{title}</h3>
-        <span className="bg-gray-200 dark:bg-slate-700 text-xs px-2 py-1 rounded-full text-muted">
-          {columnTasks.length}
-        </span>
-      </div>
-      <div className="flex flex-col gap-3">
-        {columnTasks.map((task) => (
-          <TaskItem
-            key={task._id}
-            task={task}
-            onToggleComplete={onToggleComplete}
-            onDelete={onDelete}
-            onEdit={onEdit}
-            onUpdate={onUpdate}
-            isSelected={selectedIds.includes(task._id)}
-            onSelect={onSelect}
-          />
-        ))}
-        {columnTasks.length === 0 && (
-          <div className="text-center text-sm text-muted py-8 border-2 border-dashed border-gray-200 dark:border-slate-700 rounded-lg">
-            No tasks {status.toLowerCase()}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+  const columnProps = {
+    onToggleComplete,
+    onDelete,
+    onEdit,
+    onUpdate,
+    selectedIds,
+    onSelect,
+  };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 animate-in w-full">
-      <Column title="Due" columnTasks={dueTasks} status="Due" />
-      <Column title="In Progress" columnTasks={inProgressTasks} status="In Progress" />
-      <Column title="Completed" columnTasks={completedTasks} status="Completed" />
+      <Column title="Due" columnTasks={dueTasks} status="Due" {...columnProps} />
+      <Column title="In Progress" columnTasks={inProgressTasks} status="In Progress" {...columnProps} />
+      <Column title="Completed" columnTasks={completedTasks} status="Completed" {...columnProps} />
     </div>
   );
 }

--- a/frontend/src/components/Task/TaskItem.jsx
+++ b/frontend/src/components/Task/TaskItem.jsx
@@ -1,4 +1,4 @@
-import { Check, Trash2, Pencil, Calendar } from "lucide-react";
+import { Check, Trash2, Pencil, Calendar, Play } from "lucide-react";
 import { useState } from "react";
 import TaskFormModal from "./TaskFormModal";
 import { getCategoryColor } from "../../utils/categoryUtils";
@@ -98,7 +98,25 @@ export default function TaskItem({ task, onToggleComplete, onDelete, onUpdate, i
           </div>
 
           {/* Actions */}
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            {task.status === "Due" && (
+              <button
+                onClick={() => onUpdate(task._id, { status: "In Progress" })}
+                className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded hover:bg-blue-200 dark:hover:bg-blue-900/50 transition cursor-pointer"
+                title="Start Task"
+              >
+                <Play size={14} /> <span className="hidden sm:inline">Start</span>
+              </button>
+            )}
+            {task.status === "In Progress" && (
+              <button
+                onClick={() => onToggleComplete(task)}
+                className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300 rounded hover:bg-green-200 dark:hover:bg-green-900/50 transition cursor-pointer"
+                title="Complete Task"
+              >
+                <Check size={14} /> <span className="hidden sm:inline">Complete</span>
+              </button>
+            )}
             {/* Edit Button */}
             <button
               onClick={() => setIsEditModalOpen(true)}

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import useTasks from "../hooks/useTasks";
 import TaskItem from "../components/Task/TaskItem";
 import TaskFormModal from "../components/Task/TaskFormModal";
+import KanbanBoard from "../components/Task/KanbanBoard";
 import {
   Plus,
   ArrowLeft,
@@ -14,6 +15,8 @@ import {
   Pencil,
   ChevronLeft,
   ChevronRight,
+  LayoutList,
+  Kanban,
 } from "lucide-react";
 import { getCategoryColor } from "../utils/categoryUtils";
 import EmptyState from "../components/EmptyState";
@@ -47,6 +50,7 @@ export default function Tasks() {
   const [durationModalTask, setDurationModalTask] = useState(null);
   const [actualDuration, setActualDuration] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
+  const [viewMode, setViewMode] = useState("list");
 
   const handleSelect = (id) => {
     setSelectedIds((prev) =>
@@ -318,6 +322,32 @@ export default function Tasks() {
                 )}
               </div>
 
+              {/* View Toggle */}
+              <div className="flex items-center gap-1 bg-gray-100 dark:bg-slate-800 p-1 rounded-lg">
+                <button
+                  onClick={() => setViewMode("list")}
+                  className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                    viewMode === "list"
+                      ? "bg-white dark:bg-slate-700 shadow-sm text-main"
+                      : "text-muted hover:text-main"
+                  }`}
+                >
+                  <LayoutList size={16} />
+                  <span className="hidden sm:inline">List</span>
+                </button>
+                <button
+                  onClick={() => setViewMode("board")}
+                  className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                    viewMode === "board"
+                      ? "bg-white dark:bg-slate-700 shadow-sm text-main"
+                      : "text-muted hover:text-main"
+                  }`}
+                >
+                  <Kanban size={16} />
+                  <span className="hidden sm:inline">Board</span>
+                </button>
+              </div>
+
               {/* Task Search Input Field */}
               <div className="relative w-full sm:w-64">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -368,14 +398,29 @@ export default function Tasks() {
           </div>
         </div>
 
-        {/* Task List */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-4 animate-in delay-200">
+        {/* Task List / Board */}
+        <div className={`grid ${viewMode === "list" ? "grid-cols-1 lg:grid-cols-3" : "grid-cols-1"} gap-6`}>
+          <div className={`${viewMode === "list" ? "lg:col-span-2" : "col-span-1"} space-y-4 animate-in delay-200`}>
             {filteredTasks.length ? (
-              filteredTasks.map((task) => (
-                <TaskItem
-                  key={task._id}
-                  task={task}
+              viewMode === "list" ? (
+                filteredTasks.map((task) => (
+                  <TaskItem
+                    key={task._id}
+                    task={task}
+                    onToggleComplete={handleToggle}
+                    onDelete={(id) => deleteTask(id)}
+                    onEdit={(task) => {
+                      setEditingTask(task);
+                      setIsModalOpen(true);
+                    }}
+                    onUpdate={updateTask}
+                    isSelected={selectedIds.includes(task._id)}
+                    onSelect={handleSelect}
+                  />
+                ))
+              ) : (
+                <KanbanBoard
+                  tasks={filteredTasks}
                   onToggleComplete={handleToggle}
                   onDelete={(id) => deleteTask(id)}
                   onEdit={(task) => {
@@ -383,10 +428,10 @@ export default function Tasks() {
                     setIsModalOpen(true);
                   }}
                   onUpdate={updateTask}
-                  isSelected={selectedIds.includes(task._id)}
+                  selectedIds={selectedIds}
                   onSelect={handleSelect}
                 />
-              ))
+              )
             ) : (
               <EmptyState
                 type="tasks"
@@ -424,8 +469,9 @@ export default function Tasks() {
             )}
           </div>
 
-          {/* Insights Sidebar */}
-          <div className="hidden lg:flex flex-col gap-6 animate-in delay-300">
+          {/* Insights Sidebar - Only show in list view for better board space */}
+          {viewMode === "list" && (
+            <div className="hidden lg:flex flex-col gap-6 animate-in delay-300">
             {/* Unified Insights Card */}
             <div className="card p-6 shadow-sm flex flex-col gap-6">
               {/* Completion */}
@@ -510,6 +556,7 @@ export default function Tasks() {
               </div>
             </div>
           </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## 🛠️ Related Issue

Closes: #1286 

## 📌 Description
Added a Kanban Board View to the Tasks page, allowing users to switch between List View and Board View for better task visualization and workflow management.
The board groups tasks into status-based columns (Due, In Progress, and Completed), making it easier to track progress and manage tasks visually. This enhancement improves productivity and provides a more intuitive alternative to the traditional list layout.

## ✨ Changes Made
* Added a List / Board view toggle to the Tasks page
* Created a reusable Kanban Board component
* Grouped tasks into Due, In Progress, and Completed columns
* Added task actions to move tasks between statuses
* Implemented a responsive board layout for different screen sizes
* Preserved existing list view functionality

## 📷 Screenshots
<img width="1888" height="918" alt="image" src="https://github.com/user-attachments/assets/3d8396eb-c4c1-4b61-a878-6e53781cd67f" />
https://github.com/user-attachments/assets/732c0a34-104e-42ed-b469-7d57eec83ca2

## 🧪 Type of Change
* [ ] Bug fix
* [x] New feature
* [ ] UI/UX improvement
* [ ] Documentation update

## ✔️ Checklist
* [x] My code follows the project's coding style
* [x] I have tested my changes
* [ ] I have updated documentation if needed
* [x] This PR does not break existing functionality