### PR TITLE
fix: remove misplaced CSS block from index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,15 +8,16 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>DailyForge</title>
-  <meta name="description" content="DailyForge — your personal productivity app to manage tasks, routines and daily goals." />
+  <meta name="description"
+    content="DailyForge — your personal productivity app to manage tasks, routines and daily goals." />
   <script src="https://accounts.google.com/gsi/client" async defer></script>
-<meta property="og:title" content="DailyForge" />
-<meta property="og:description" content="Manage your daily tasks, routines and goals with DailyForge." />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="https://dailyforge.app" />
-<meta name="twitter:card" content="summary" />
-<meta name="twitter:title" content="DailyForge" />
-<meta name="twitter:description" content="Manage your daily tasks, routines and goals with DailyForge." />
+  <meta property="og:title" content="DailyForge" />
+  <meta property="og:description" content="Manage your daily tasks, routines and goals with DailyForge." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://dailyforge.app" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="DailyForge" />
+  <meta name="twitter:description" content="Manage your daily tasks, routines and goals with DailyForge." />
 </head>
 
 <body>
@@ -25,88 +26,3 @@
 </body>
 
 </html>
-
-/* Navbar Container */
-.navbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
-/* Navigation Links */
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  list-style: none;
-  flex-wrap: wrap;
-}
-
-/* Nav Link Styling */
-.nav-links a {
-  text-decoration: none;
-  font-size: 1rem;
-  transition: 0.3s ease;
-}
-
-/* Better Hover Effect */
-.nav-links a:hover {
-  opacity: 0.8;
-}
-
-/* Tablet Responsiveness */
-@media screen and (max-width: 992px) {
-  .navbar {
-    padding: 1rem;
-  }
-
-  .nav-links {
-    gap: 1rem;
-  }
-
-  .nav-links a {
-    font-size: 0.95rem;
-  }
-}
-
-/* Mobile Responsiveness */
-@media screen and (max-width: 768px) {
-
-  .navbar {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-  }
-
-  .nav-links {
-    justify-content: center;
-    margin-top: 1rem;
-    gap: 0.8rem;
-  }
-
-  .nav-links a {
-    font-size: 0.9rem;
-  }
-}
-
-/* Small Mobile Devices */
-@media screen and (max-width: 480px) {
-
-  .navbar {
-    padding: 0.8rem;
-  }
-
-  .nav-links {
-    flex-direction: column;
-    width: 100%;
-  }
-
-  .nav-links a {
-    width: 100%;
-    display: block;
-    padding: 0.5rem 0;
-  }
-}


### PR DESCRIPTION
## Description
Removed misplaced CSS block from `index.html` that was placed outside 
the closing `</html>` tag, causing raw CSS code to render as visible 
plain text at the bottom of the webpage instead of being applied as styles.

## Related Issue
Closes #<issue-number>

## Changes Made
- Removed misplaced CSS block from `index.html` that was outside `</html>` tag
- Cleaned up `index.html` to contain only valid HTML structure

## Screenshots (if UI changes)
**Before:** 
<img width="1890" height="862" alt="afterthe-bug" src="https://github.com/user-attachments/assets/d1ad5be0-f92a-4ceb-9d76-44c610b40b35" />

**After:** 
<img width="1887" height="862" alt="beforethe-bug" src="https://github.com/user-attachments/assets/0459b0a7-bd61-4401-8c9d-ac50107519bf" />


<!-- Attach before/after screenshots -->

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch follows the naming convention
- [x] I have tested this locally
- [x] Linting passes (`npm run lint` in frontend/)
- [x] No unrelated files were modified
- [ ] Screenshots are attached (if UI change)