### PR TITLE
feat(auth): add rate limiting to signup, login, and google-login

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import {
   signup,
   login,
@@ -16,21 +16,41 @@ import { authMiddleware } from '../middlewares/authMiddleware.js';
 
 const router = express.Router();
 
-// ─── Rate limiter for all 2FA endpoints ───────────────────────────────────────
-// Max 5 attempts per 15 minutes — prevents brute-force on TOTP codes
-const twoFALimiter = rateLimit({
+const RATE_LIMIT_MESSAGE = { message: 'Too many attempts, please try again later' };
+
+const baseAuthLimitOptions = {
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 5,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { message: 'Too many attempts, please try again later' },
+  message: RATE_LIMIT_MESSAGE,
+};
+
+const normalizeEmail = (req) => String(req.body?.email ?? '').trim().toLowerCase();
+
+// Max 10 auth attempts per IP per 15 minutes — caps credential stuffing / signup spam
+const authByIpLimiter = rateLimit({
+  ...baseAuthLimitOptions,
+  max: 10,
+  keyGenerator: (req) => ipKeyGenerator(req.ip),
 });
-// ──────────────────────────────────────────────────────────────────────────────
+
+// Max 5 attempts per email per 15 minutes — protects individual accounts from brute-force
+const authByEmailLimiter = rateLimit({
+  ...baseAuthLimitOptions,
+  max: 5,
+  keyGenerator: (req) => normalizeEmail(req) || ipKeyGenerator(req.ip),
+});
+
+// Max 5 attempts per 15 minutes — prevents brute-force on TOTP codes
+const twoFALimiter = rateLimit({
+  ...baseAuthLimitOptions,
+  max: 5,
+});
 
 // Public routes
-router.post('/signup', signup);
-router.post('/login', login);
-router.post('/google-login', googleLogin);
+router.post('/signup', authByIpLimiter, authByEmailLimiter, signup);
+router.post('/login', authByIpLimiter, authByEmailLimiter, login);
+router.post('/google-login', authByIpLimiter, googleLogin);
 
 // 2FA login completion (rate limited — protects TOTP brute-force)
 router.post('/login-2fa', twoFALimiter, loginWith2FA);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,6 +16,8 @@ const PORT = process.env.PORT;
 // Initialize express     
 const app = express();
 
+// Required for correct req.ip behind Render / reverse proxies (used by rate limiting)
+app.set('trust proxy', 1);
 
 app.use(
   cors({


### PR DESCRIPTION
Layer IP and email limits on public auth endpoints and enable trust proxy so rate limiting works correctly behind Render.

## 📌 Description
Adds rate limiting to `/signup`, `/login`, and `/google-login` to reduce brute-force login attempts, credential stuffing, and signup spam. Limits follow the existing 2FA pattern with a generic error message that does not reveal which limit was hit.

## 🔗 Related Issue
Closes #1418

## 🛠 Changes Made
- Added `authByIpLimiter` (10 requests / 15 min per IP) for `/signup`, `/login`, and `/google-login`
- Added `authByEmailLimiter` (5 requests / 15 min per normalized email) for `/signup` and `/login`
- Refactored shared rate-limit config and reused it for existing 2FA limiters
- Used `ipKeyGenerator` for IPv6-safe IP keys (express-rate-limit v8)
- Enabled `trust proxy` in `server.js` so IP-based limits work behind Render

## 📸 Screenshots (if applicable)
N/A — backend-only change, no UI updates.

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [ ] Linked the issue

## 🚀 Notes for Reviewers
- `/google-login` is IP-limited only because email is inside the Firebase token and is not available before verification.
- Login and signup use stacked IP + email limiters; both must pass before the controller runs.
- Verified manually: 429 on 6th login attempt (same email) and 11th google-login attempt (same IP), with generic `"Too many attempts, please try again later"` message and `RateLimit-*` headers.
- Replace `#<issue_number>` with the assigned GSSoC issue before opening the PR.