### PR TITLE
feat: add export & share routine feature (#1133)

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -407,3 +407,24 @@ export const deleteRoutine = async (req, res) => {
       .json({ success: false, message: "Error deleting routine" });
   }
 };
+
+// Fetch public routine function (unauthenticated)
+export const getPublicRoutine = async (req, res) => {
+  try {
+    const routineId = req.params.id;
+    const routine = await Routine.findById(routineId).populate("items.taskId");
+    if (!routine) {
+      return res.status(404).json({
+        success: false,
+        message: "Routine not found",
+      });
+    }
+    return res.status(200).json({ success: true, routine });
+  } catch (error) {
+    console.log("Error fetching public routine", error);
+    return res
+      .status(500)
+      .json({ success: false, message: "Error fetching public routine" });
+  }
+};
+

--- a/backend/routes/routineRoutes.js
+++ b/backend/routes/routineRoutes.js
@@ -5,6 +5,7 @@ import {
   duplicateRoutine,
   getRoutines,
   updateRoutine,
+  getPublicRoutine,
 } from "../controllers/routineController.js";
 import { authMiddleware } from "../middlewares/authMiddleware.js";
 import mongoose from "mongoose";
@@ -38,3 +39,6 @@ routineRouter.put("/:id", authMiddleware, validateObjectId, asyncHandler(updateR
 
 // Route for deleting routine
 routineRouter.delete("/:id", authMiddleware, validateObjectId, asyncHandler(deleteRoutine));
+
+// Route for fetching public routine (unauthenticated)
+routineRouter.get("/public/:id", validateObjectId, asyncHandler(getPublicRoutine));

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "gsap": "^3.15.0",
         "html-to-image": "^1.11.13",
         "html2canvas": "^1.4.1",
+        "jspdf": "^4.2.1",
         "lucide-react": "^0.562.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -67,6 +68,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -268,6 +270,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -993,6 +1004,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.13.tgz",
       "integrity": "sha512-H89Jeyp31+EZk9GPu6vaeL9mEmoXgM3nASB7UPBYYS/lqAks21mO1BU1dF8NbsVTL6tgGZkGUtiGJgxtDiwHkw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
@@ -1059,6 +1071,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.13.tgz",
       "integrity": "sha512-pn3FvXwUR34kWPccDQfCKsNZcM2wD1OS+J1jeEgzM1ZNXoxR2NaF6e5DjDuRrnTwR6LN2XQQt0IqE6yKmgpCQg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.13",
         "@firebase/component": "0.7.3",
@@ -1075,6 +1088,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
       "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.1"
       }
@@ -1528,6 +1542,7 @@
       "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2388,12 +2403,26 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2407,6 +2436,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
@@ -2435,6 +2471,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2574,6 +2611,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2631,6 +2669,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2729,6 +2787,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2801,6 +2871,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2957,6 +3037,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3156,6 +3237,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
@@ -3184,6 +3276,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3598,6 +3696,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3711,6 +3815,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -4196,6 +4317,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4229,6 +4356,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4240,6 +4374,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4328,11 +4463,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4342,6 +4488,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4397,6 +4544,13 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4414,6 +4568,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -4534,6 +4698,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4584,6 +4758,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -4720,6 +4904,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4923,6 +5108,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "gsap": "^3.15.0",
     "html-to-image": "^1.11.13",
     "html2canvas": "^1.4.1",
+    "jspdf": "^4.2.1",
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,8 @@ import Profile from './pages/Profile.jsx';
 import ScrollToTop from "./components/ScrollToTop.jsx";
 import ErrorBoundary from "./components/ErrorBoundary.jsx";
 import PageTransition from "./components/PageTransition.jsx";
+import ShareRoutine from "./pages/ShareRoutine.jsx";
+
 
 const AuthLayout = ({ children }) => (
   <div className="min-h-[calc(100vh-3.75rem)] flex items-center justify-center px-4">
@@ -136,8 +138,10 @@ const App = () => {
               </ProtectedRoutes>
             }
           />
+          <Route path="/share/routine/:id" element={<ShareRoutine />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
+
       </main>
       <Footer />
       <ScrollToTop />

--- a/frontend/src/components/Routine/RoutineCard.jsx
+++ b/frontend/src/components/Routine/RoutineCard.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { MoreVertical, Trash2 } from "lucide-react";
+import { MoreVertical, Trash2, Share2, Copy, Download, Loader2 } from "lucide-react";
 import RoutineOverviewModal from "./RoutineOverviewModal";
 import api from "../../api/axios.js";
+import { exportRoutineToPDF, generateRoutineSummary } from "../../utils/routineExport.js";
+
 
 export default function RoutineCard({
   routine,
@@ -15,8 +17,62 @@ export default function RoutineCard({
   const [showMenu, setShowMenu] = useState(false);
   const [showToast, setShowToast] = useState(false);
   const [showOverlapError, setShowOverlapError] = useState(false);
+  const [toastTitle, setToastTitle] = useState("Routine Started");
+  const [toastDesc, setToastDesc] = useState("Tasks were added to today's workflow.");
+  const [isExporting, setIsExporting] = useState(false);
 
   const menuRef = useRef(null);
+
+  const triggerToast = (title, desc) => {
+    setToastTitle(title);
+    setToastDesc(desc);
+    setShowToast(true);
+    setTimeout(() => {
+      setShowToast(false);
+    }, 3000);
+  };
+
+  const handleCopyLink = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      const shareUrl = `${window.location.origin}/share/routine/${routine._id}`;
+      await navigator.clipboard.writeText(shareUrl);
+      triggerToast("Share Link Copied", "The public routine link was copied to clipboard.");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to copy share link");
+    }
+  };
+
+  const handleCopySummary = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      const summaryText = generateRoutineSummary(routine, tasks);
+      await navigator.clipboard.writeText(summaryText);
+      triggerToast("Summary Copied", "The routine summary text was copied to clipboard.");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to copy routine summary");
+    }
+  };
+
+  const handleExportPDF = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      setIsExporting(true);
+      await exportRoutineToPDF(routine, tasks);
+      triggerToast("PDF Downloaded", "The routine PDF was generated and downloaded successfully.");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to export routine as PDF");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
 
   const isRoutineStarted =
   activeRoutine.some(
@@ -160,11 +216,7 @@ export default function RoutineCard({
     ])
   );
 
-  setShowToast(true);
-
-  setTimeout(() => {
-    setShowToast(false);
-  }, 3000);
+  triggerToast("Routine Started", "Tasks were added to today's workflow.");
 };
 
  
@@ -261,11 +313,11 @@ export default function RoutineCard({
 
               <div>
                 <p className="text-sm font-semibold text-main">
-                  Routine Started
+                  {toastTitle}
                 </p>
 
                 <p className="text-xs text-muted mt-1">
-                  Tasks were added to today's workflow.
+                  {toastDesc}
                 </p>
               </div>
 
@@ -275,6 +327,7 @@ export default function RoutineCard({
 
         </div>
       )}
+
 
       {/* Card */}
       <div
@@ -353,7 +406,30 @@ export default function RoutineCard({
           </button>
 
           {showMenu && (
-            <div className="absolute right-0 mt-1 w-44 rounded-2xl border border-soft bg-white dark:bg-[#1e293b] shadow-xl overflow-hidden z-50 animate-in fade-in duration-200">
+            <div className="absolute right-0 mt-1 w-48 rounded-2xl border border-soft bg-white dark:bg-[#1e293b] shadow-xl overflow-hidden z-50 animate-in fade-in duration-200">
+              <button
+                onClick={handleCopyLink}
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer"
+              >
+                <Share2 size={16} />
+                Copy Share Link
+              </button>
+              <button
+                onClick={handleCopySummary}
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer"
+              >
+                <Copy size={16} />
+                Copy Summary
+              </button>
+              <button
+                onClick={handleExportPDF}
+                disabled={isExporting}
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer disabled:opacity-50"
+              >
+                {isExporting ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+                Export as PDF
+              </button>
+              <div className="border-t border-soft/20"></div>
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -366,6 +442,7 @@ export default function RoutineCard({
               </button>
             </div>
           )}
+
         </div>
       </div>
 

--- a/frontend/src/components/Routine/RoutineOverviewModal.jsx
+++ b/frontend/src/components/Routine/RoutineOverviewModal.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { MoreVertical, Trash2, X, Calendar, Layers, Clock } from "lucide-react";
+import { MoreVertical, Trash2, X, Calendar, Layers, Clock, Share2, Copy, Download, Loader2 } from "lucide-react";
+import { exportRoutineToPDF, generateRoutineSummary } from "../../utils/routineExport.js";
 
 export default function RoutineOverviewModal({
   routine,
@@ -11,6 +12,9 @@ export default function RoutineOverviewModal({
   handleDeleteRoutine,
 }) {
   const [showMenu, setShowMenu] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+  const [showToast, setShowToast] = useState(false);
 
   useEffect(() => {
     document.body.style.overflow = "hidden";
@@ -18,6 +22,55 @@ export default function RoutineOverviewModal({
       document.body.style.overflow = "auto";
     };
   }, []);
+
+  const triggerToast = (msg) => {
+    setToastMessage(msg);
+    setShowToast(true);
+    setTimeout(() => {
+      setShowToast(false);
+    }, 3000);
+  };
+
+  const handleCopyLink = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      const shareUrl = `${window.location.origin}/share/routine/${routine._id}`;
+      await navigator.clipboard.writeText(shareUrl);
+      triggerToast("Share link copied!");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to copy share link");
+    }
+  };
+
+  const handleCopySummary = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      const summaryText = generateRoutineSummary(routine, tasks);
+      await navigator.clipboard.writeText(summaryText);
+      triggerToast("Routine summary copied!");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to copy summary");
+    }
+  };
+
+  const handleExportPDF = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      setIsExporting(true);
+      await exportRoutineToPDF(routine, tasks);
+      triggerToast("PDF generated!");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to export PDF");
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   const tasksByDay = routine.items.reduce((acc, item) => {
     if (!acc[item.day]) acc[item.day] = [];
@@ -31,6 +84,20 @@ export default function RoutineOverviewModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm px-4 animate-in">
+      {/* Toast Notification */}
+      {showToast && (
+        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-[100] animate-in slide-in-from-top duration-300">
+          <div className="rounded-2xl border border-soft bg-white dark:bg-[#1e293b] shadow-2xl px-5 py-4 min-w-[320px]">
+            <div className="flex items-start gap-3">
+              <div className="mt-1 h-3 w-3 rounded-full bg-green-500" />
+              <div>
+                <p className="text-sm font-semibold text-main">{toastMessage}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="w-full max-w-2xl rounded-3xl p-6 bg-white dark:bg-[#1e293b] shadow-2xl border border-soft/50 max-h-[90vh] overflow-y-auto flex flex-col justify-between">
         
         {/* Header */}
@@ -72,7 +139,30 @@ export default function RoutineOverviewModal({
             </button>
 
             {showMenu && (
-              <div className="absolute top-12 right-10 w-44 rounded-2xl border border-soft bg-white dark:bg-[#1e293b] shadow-xl overflow-hidden z-50 animate-in fade-in duration-200">
+              <div className="absolute top-12 right-10 w-48 rounded-2xl border border-soft bg-white dark:bg-[#1e293b] shadow-xl overflow-hidden z-50 animate-in fade-in duration-200">
+                <button
+                  onClick={handleCopyLink}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer"
+                >
+                  <Share2 size={16} />
+                  Copy Share Link
+                </button>
+                <button
+                  onClick={handleCopySummary}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer"
+                >
+                  <Copy size={16} />
+                  Copy Summary
+                </button>
+                <button
+                  onClick={handleExportPDF}
+                  disabled={isExporting}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer disabled:opacity-50"
+                >
+                  {isExporting ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+                  Export as PDF
+                </button>
+                <div className="border-t border-soft/20"></div>
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
@@ -85,6 +175,7 @@ export default function RoutineOverviewModal({
                 </button>
               </div>
             )}
+
           
 
             {/* Close */}

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -13,7 +13,7 @@ import TaskFormModal from "../components/Task/TaskFormModal";
 import RoutineCard from "../components/Routine/RoutineCard.jsx";
 import useTasks from "../hooks/useTasks.js";
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Download } from "lucide-react";
+import { ArrowLeft, Download, Loader2 } from "lucide-react";
 import { toPng } from "html-to-image";
 import api from "../api/axios.js";
 import EmptyState from "../components/EmptyState";
@@ -32,11 +32,13 @@ export default function RoutineBuilder() {
   const [activeRoutine, setActiveRoutine] = useState([]);
   const [description, setDescription] = useState("");
   const [activeTask, setActiveTask] = useState(null);
+  const [isImageExporting, setIsImageExporting] = useState(false);
   const gridRef = useRef(null);
 
   const exportToImage = async () => {
     if (!gridRef.current) return;
     try {
+      setIsImageExporting(true);
       // html-to-image handles CSS variables and Google Fonts without CORS issues
       const url = await toPng(gridRef.current, { cacheBust: true, pixelRatio: 2 });
       const link = document.createElement("a");
@@ -48,6 +50,8 @@ export default function RoutineBuilder() {
     } catch (error) {
       console.error("Export failed:", error);
       alert("Failed to export routine as image.");
+    } finally {
+      setIsImageExporting(false);
     }
   };
 
@@ -221,10 +225,11 @@ export default function RoutineBuilder() {
           </div>
           <button
             onClick={exportToImage}
-            className="btn btn-primary flex items-center gap-2 cursor-pointer hover-lift"
+            disabled={isImageExporting}
+            className="btn btn-primary flex items-center gap-2 cursor-pointer hover-lift disabled:opacity-50"
           >
-            <Download size={16} />
-            Export as PNG
+            {isImageExporting ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+            {isImageExporting ? "Exporting..." : "Export as PNG"}
           </button>
         </header>
 

--- a/frontend/src/pages/ShareRoutine.jsx
+++ b/frontend/src/pages/ShareRoutine.jsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Calendar, Clock, Layers, Download, Copy, ArrowLeft, Sparkles } from "lucide-react";
+import api from "../api/axios.js";
+import LoadingSpinner from "../components/common/LoadingSpinner.jsx";
+import { exportRoutineToPDF, generateRoutineSummary } from "../utils/routineExport.js";
+
+export default function ShareRoutine() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [routine, setRoutine] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [showCopyToast, setShowCopyToast] = useState(false);
+
+  useEffect(() => {
+    const fetchPublicRoutine = async () => {
+      try {
+        setLoading(true);
+        const res = await api.get(`/routines/public/${id}`);
+        if (res.data.success && res.data.routine) {
+          setRoutine(res.data.routine);
+        } else {
+          setError("Routine not found or cannot be loaded.");
+        }
+      } catch (err) {
+        console.error("Error loading public routine:", err);
+        setError(err.response?.data?.message || "Failed to load the routine. It might not exist or the link is invalid.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPublicRoutine();
+  }, [id]);
+
+  const handleCopySummary = async () => {
+    if (!routine) return;
+    try {
+      const summaryText = generateRoutineSummary(routine, []);
+      await navigator.clipboard.writeText(summaryText);
+      setShowCopyToast(true);
+      setTimeout(() => setShowCopyToast(false), 3000);
+    } catch (err) {
+      console.error("Failed to copy summary:", err);
+      alert("Failed to copy routine summary.");
+    }
+  };
+
+  const handleExportPDF = async () => {
+    if (!routine) return;
+    try {
+      setIsExporting(true);
+      await exportRoutineToPDF(routine, []);
+    } catch (err) {
+      console.error("PDF export failed:", err);
+      alert("Failed to export routine as PDF.");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center app-bg">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (error || !routine) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center app-bg px-4 text-center">
+        <div className="card max-w-md w-full p-8 border-red-500/20 bg-white dark:bg-[#1e293b] shadow-xl">
+          <h2 className="text-xl font-bold text-red-500 mb-2">Failed to load routine</h2>
+          <p className="text-sm text-muted mb-6">{error || "The requested routine is unavailable."}</p>
+          <button
+            onClick={() => navigate("/login")}
+            className="btn btn-primary w-full"
+          >
+            Go to DailyForge Login
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Group items by day
+  const tasksByDay = routine.items.reduce((acc, item) => {
+    if (!acc[item.day]) acc[item.day] = [];
+    acc[item.day].push({
+      ...item,
+      title: item.taskId?.title || "Unknown Task",
+    });
+    return acc;
+  }, {});
+
+  const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+  const activeDays = days.filter(d => tasksByDay[d] && tasksByDay[d].length > 0);
+
+  return (
+    <div className="min-h-screen w-full max-w-[1000px] mx-auto app-bg px-6 py-10 space-y-8 animate-in pb-40">
+      
+      {/* Toast Notification */}
+      {showCopyToast && (
+        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-[100] animate-in slide-in-from-top duration-300">
+          <div className="rounded-2xl border border-soft bg-white dark:bg-[#1e293b] shadow-2xl px-5 py-4 min-w-[320px]">
+            <div className="flex items-start gap-3">
+              <div className="mt-1 h-3 w-3 rounded-full bg-green-500" />
+              <div>
+                <p className="text-sm font-semibold text-main">Summary Copied</p>
+                <p className="text-xs text-muted mt-1">Routine text summary copied to clipboard.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Header Navigation */}
+      <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate("/login")}
+            className="rounded-lg p-2 border border-soft text-muted hover:bg-white dark:hover:bg-slate-800 transition cursor-pointer"
+            title="Go to Login"
+          >
+            <ArrowLeft size={16} />
+          </button>
+          <div>
+            <span className="text-xs font-bold text-primary uppercase tracking-wider">Shared via DailyForge</span>
+            <h1 className="text-2xl font-bold text-main">Public Routine View</h1>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleCopySummary}
+            className="btn border border-soft hover:bg-white dark:hover:bg-slate-800 flex items-center gap-2 text-sm text-main"
+            title="Copy Text Summary"
+          >
+            <Copy size={15} />
+            Copy Summary
+          </button>
+
+          <button
+            onClick={handleExportPDF}
+            disabled={isExporting}
+            className="btn btn-primary flex items-center gap-2 text-sm disabled:opacity-50"
+          >
+            <Download size={15} />
+            {isExporting ? "Exporting PDF..." : "Export as PDF"}
+          </button>
+        </div>
+      </header>
+
+      {/* Routine Detail Card */}
+      <div className="card border border-soft bg-white dark:bg-[#1e293b] p-6 sm:p-8 flex flex-col md:flex-row md:items-start justify-between gap-6">
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-2xl font-bold text-main">{routine.name}</h2>
+            {routine.description ? (
+              <p className="text-sm text-muted mt-2 italic leading-relaxed max-w-2xl">{routine.description}</p>
+            ) : (
+              <p className="text-sm text-muted/50 mt-2 italic">No description provided.</p>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 text-xs font-semibold">
+            <span className="flex items-center gap-1.5 rounded-full bg-cyan-50 dark:bg-cyan-950/40 px-3 py-1 text-cyan-600 dark:text-cyan-400 border border-cyan-100 dark:border-cyan-800/40">
+              <Layers size={12} />
+              {routine.items.length} Tasks
+            </span>
+            <span className="flex items-center gap-1.5 rounded-full bg-emerald-50 dark:bg-emerald-950/40 px-3 py-1 text-emerald-600 dark:text-emerald-400 border border-emerald-100 dark:border-emerald-800/40">
+              <Calendar size={12} />
+              {activeDays.length} Active Days
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Routine Timeline */}
+      <div className="space-y-6">
+        {activeDays.length === 0 ? (
+          <div className="card text-center py-12 border border-soft/50">
+            <p className="text-muted italic">This routine does not contain any scheduled tasks.</p>
+          </div>
+        ) : (
+          activeDays.map((day) => (
+            <div key={day} className="space-y-3">
+              <h3 className="text-base font-bold text-main uppercase tracking-wider border-l-4 border-[#4eb7b3] pl-2.5">
+                {day}
+              </h3>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pl-3">
+                {tasksByDay[day]
+                  .sort((a, b) => a.startTime - b.startTime)
+                  .map((task) => {
+                    const hours = String(Math.floor(task.startTime / 60)).padStart(2, "0");
+                    const minutes = String(task.startTime % 60).padStart(2, "0");
+                    
+                    return (
+                      <div
+                        key={task._id}
+                        className="rounded-2xl border border-soft/30 bg-white dark:bg-slate-800/40 p-4 hover:shadow-md hover:border-soft/60 transition duration-200 flex items-center justify-between gap-4"
+                      >
+                        <div className="flex items-center gap-3 min-w-0">
+                          <span className="h-2.5 w-2.5 rounded-full bg-[#4eb7b3] shrink-0" />
+                          <div className="min-w-0">
+                            <p className="text-sm font-semibold text-main truncate">{task.title}</p>
+                            <p className="text-[11px] text-muted mt-0.5 flex items-center gap-1">
+                              <Clock size={10} />
+                              {task.duration} minutes
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="text-xs font-semibold text-main rounded-xl border border-soft/40 px-3 py-1 bg-slate-50 dark:bg-slate-800 shrink-0">
+                          {hours}:{minutes}
+                        </div>
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Call to Action Section */}
+      <div className="card border-0 bg-gradient-to-br from-[#4eb7b3]/20 via-transparent to-transparent dark:from-[#1e2e30] relative overflow-hidden p-8 flex flex-col md:flex-row justify-between items-center gap-6">
+        <div className="space-y-2 text-center md:text-left">
+          <div className="flex items-center justify-center md:justify-start gap-2 text-primary">
+            <Sparkles size={16} className="animate-pulse" />
+            <span className="text-xs font-bold uppercase tracking-wider">Start Forging Your Day</span>
+          </div>
+          <h3 className="text-xl font-bold text-main">Like this routine template?</h3>
+          <p className="text-sm text-muted max-w-xl">
+            Sign up for DailyForge to easily build weekly schedules, track your sustainability and burnout scores, and adapt your day to your energy.
+          </p>
+        </div>
+
+        <button
+          onClick={() => navigate("/signup")}
+          className="btn btn-primary shrink-0 hover-lift w-full md:w-auto px-6 py-3 text-base"
+        >
+          Create Free Account
+        </button>
+      </div>
+
+    </div>
+  );
+}

--- a/frontend/src/utils/routineExport.js
+++ b/frontend/src/utils/routineExport.js
@@ -1,0 +1,200 @@
+import html2canvas from "html2canvas";
+import { jsPDF } from "jspdf";
+
+// Helper to resolve the task title from either populated object or task list
+const getTaskTitle = (item, tasksList) => {
+  if (item.taskId && typeof item.taskId === 'object' && item.taskId.title) {
+    return item.taskId.title;
+  }
+  const task = tasksList?.find((t) => String(t._id) === String(item.taskId));
+  return task?.title || "Unknown Task";
+};
+
+// Generates a readable plain-text summary of a routine
+export const generateRoutineSummary = (routine, tasksList) => {
+  const tasksByDay = routine.items.reduce((acc, item) => {
+    if (!acc[item.day]) acc[item.day] = [];
+    const title = getTaskTitle(item, tasksList);
+    acc[item.day].push({
+      ...item,
+      title,
+    });
+    return acc;
+  }, {});
+
+  let summary = `Routine: ${routine.name}\n`;
+  if (routine.description) {
+    summary += `Description: ${routine.description}\n`;
+  }
+  summary += `\n`;
+
+  const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+  days.forEach((day) => {
+    if (tasksByDay[day] && tasksByDay[day].length > 0) {
+      summary += `${day.toUpperCase()}:\n`;
+      tasksByDay[day]
+        .sort((a, b) => a.startTime - b.startTime)
+        .forEach((task) => {
+          const hours = String(Math.floor(task.startTime / 60)).padStart(2, "0");
+          const minutes = String(task.startTime % 60).padStart(2, "0");
+          summary += `- ${hours}:${minutes} (${task.duration} mins): ${task.title}\n`;
+        });
+      summary += `\n`;
+    }
+  });
+
+  return summary.trim();
+};
+
+// Generates and downloads a print-friendly PDF of the routine
+export const exportRoutineToPDF = async (routine, tasksList) => {
+  // 1. Create a styled container for printing
+  const container = document.createElement("div");
+  container.style.position = "fixed";
+  container.style.left = "-9999px";
+  container.style.top = "-9999px";
+  container.style.width = "800px";
+  container.style.padding = "40px";
+  container.style.background = "#ffffff";
+  container.style.color = "#1e293b";
+  container.style.fontFamily = "'Outfit', 'Inter', sans-serif";
+  container.style.boxSizing = "border-box";
+
+  // 2. Group items by day
+  const tasksByDay = routine.items.reduce((acc, item) => {
+    if (!acc[item.day]) acc[item.day] = [];
+    const title = getTaskTitle(item, tasksList);
+    acc[item.day].push({
+      ...item,
+      title,
+    });
+    return acc;
+  }, {});
+
+  const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+  let daysHTML = "";
+
+  days.forEach((day) => {
+    if (tasksByDay[day] && tasksByDay[day].length > 0) {
+      const sortedTasks = tasksByDay[day].sort((a, b) => a.startTime - b.startTime);
+      daysHTML += `
+        <div style="margin-bottom: 24px; border: 1px solid #e2e8f0; border-radius: 12px; overflow: hidden; page-break-inside: avoid;">
+          <div style="background-color: #f8fafc; border-bottom: 1px solid #e2e8f0; padding: 12px 20px; font-weight: 700; color: #3b8ea0; text-transform: uppercase; letter-spacing: 0.05em; font-size: 14px;">
+            ${day}
+          </div>
+          <div style="padding: 8px 0;">
+            ${sortedTasks
+              .map((task, index) => {
+                const hours = String(Math.floor(task.startTime / 60)).padStart(2, "0");
+                const minutes = String(task.startTime % 60).padStart(2, "0");
+                const isLast = index === sortedTasks.length - 1;
+                return `
+                  <div style="display: flex; align-items: center; justify-content: space-between; padding: 12px 20px; ${
+                    !isLast ? "border-bottom: 1px solid #f1f5f9;" : ""
+                  }">
+                    <div style="display: flex; align-items: center; gap: 12px;">
+                      <div style="width: 8px; height: 8px; border-radius: 50%; background-color: #4eb7b3;"></div>
+                      <span style="font-weight: 500; font-size: 15px; color: #1e293b;">${task.title}</span>
+                    </div>
+                    <div style="font-size: 13px; font-weight: 600; color: #64748b; background-color: #f1f5f9; padding: 4px 10px; border-radius: 8px;">
+                      ${hours}:${minutes} (${task.duration} mins)
+                    </div>
+                  </div>
+                `;
+              })
+              .join("")}
+          </div>
+        </div>
+      `;
+    }
+  });
+
+  container.innerHTML = `
+    <div style="border-bottom: 3px solid #4eb7b3; padding-bottom: 20px; margin-bottom: 30px; display: flex; justify-content: space-between; align-items: center;">
+      <div>
+        <h1 style="margin: 0; font-size: 28px; font-weight: 800; color: #3b8ea0; letter-spacing: -0.02em;">DailyForge</h1>
+        <p style="margin: 4px 0 0 0; font-size: 14px; color: #4eb7b3; font-weight: 500;">Your structured day, forged.</p>
+      </div>
+      <div style="text-align: right;">
+        <span style="display: inline-block; padding: 6px 12px; background-color: #d0f6e3; color: #3b8ea0; font-weight: 700; font-size: 11px; text-transform: uppercase; border-radius: 20px; border: 1px solid #98e1d7;">
+          Routine Template
+        </span>
+      </div>
+    </div>
+
+    <div style="margin-bottom: 30px;">
+      <h2 style="margin: 0 0 8px 0; font-size: 22px; font-weight: 700; color: #1e293b;">${routine.name}</h2>
+      ${
+        routine.description
+          ? `<p style="margin: 0; font-size: 14px; color: #64748b; font-style: italic; line-height: 1.5;">${routine.description}</p>`
+          : ""
+      }
+    </div>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 30px; background-color: #f8fafc; border-radius: 12px; padding: 16px;">
+      <div>
+        <span style="font-size: 12px; color: #64748b; display: block; margin-bottom: 4px;">Total Tasks</span>
+        <strong style="font-size: 18px; color: #1e293b;">${routine.items.length} Tasks</strong>
+      </div>
+      <div>
+        <span style="font-size: 12px; color: #64748b; display: block; margin-bottom: 4px;">Weekly Schedule</span>
+        <strong style="font-size: 18px; color: #1e293b;">${
+          new Set(routine.items.map((i) => i.day)).size
+        } Active Day(s)</strong>
+      </div>
+    </div>
+
+    <div>
+      ${
+        daysHTML ||
+        '<p style="color: #64748b; font-style: italic; text-align: center; margin-top: 40px;">No tasks scheduled in this routine.</p>'
+      }
+    </div>
+
+    <div style="margin-top: 50px; border-top: 1px dashed #e2e8f0; padding-top: 20px; text-align: center; font-size: 12px; color: #94a3b8;">
+      Generated via DailyForge. Manage your habits and schedules efficiently.
+    </div>
+  `;
+
+  document.body.appendChild(container);
+
+  try {
+    const canvas = await html2canvas(container, {
+      scale: 2,
+      useCORS: true,
+      backgroundColor: "#ffffff",
+      logging: false,
+    });
+    const imgData = canvas.toDataURL("image/png");
+
+    const pdf = new jsPDF("p", "pt", "a4");
+    const pdfWidth = pdf.internal.pageSize.getWidth();
+    const pdfHeight = pdf.internal.pageSize.getHeight();
+
+    // Scale image to fit A4 width
+    const imgWidth = pdfWidth;
+    const imgHeight = (canvas.height * imgWidth) / canvas.width;
+
+    let heightLeft = imgHeight;
+    let position = 0;
+
+    // Add first page
+    pdf.addImage(imgData, "PNG", 0, position, imgWidth, imgHeight);
+    heightLeft -= pdfHeight;
+
+    // Add extra pages if needed
+    while (heightLeft > 0) {
+      position = heightLeft - imgHeight; // position offsets page scrolling
+      pdf.addPage();
+      pdf.addImage(imgData, "PNG", 0, position, imgWidth, imgHeight);
+      heightLeft -= pdfHeight;
+    }
+
+    pdf.save(`${routine.name.replace(/\s+/g, "_")}_Routine.pdf`);
+  } catch (error) {
+    console.error("PDF generation failed:", error);
+    throw error;
+  } finally {
+    document.body.removeChild(container);
+  }
+};


### PR DESCRIPTION
## 📌 Description

Implemented the Export & Share Routine feature, allowing users to export routines, share them publicly, and copy routine summaries for easier collaboration and accessibility.

## 🔗 Related Issue

Closes #1133

## 🛠 Changes Made

* Added PDF export functionality for routines using jsPDF and html2canvas
* Added copy-to-clipboard support for routine summaries
* Added public routine sharing page and backend endpoint
* Added share link generation and copy link actions
* Enhanced weekly schedule image export with loading and disabled states
* Added user feedback through toast notifications

## 📸 Screenshots (if applicable)

Add screenshots/GIFs demonstrating:

* Export PDF action
* Copy Summary action
* Public Share Page
* Weekly Schedule Export

## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors
* [x] Properly tested changes
* [x] Linked the issue

## 🚀 Notes for Reviewers

* Public routine viewing is available through a dedicated share route.
* Existing UI patterns and toast notifications were reused to maintain consistency.
* Production build was verified successfully after implementation.
