### PR TITLE
fix: stop Pomodoro completion audio from persisting after reset and navigation

### DIFF
--- a/frontend/src/pages/Pomodoro.jsx
+++ b/frontend/src/pages/Pomodoro.jsx
@@ -10,6 +10,19 @@ const Pomodoro = () => {
 
     const finRef = useRef(new Audio(finSound));
 
+    const stopCompletionSound = () => {
+        if (finRef.current) {
+            finRef.current.pause();
+            finRef.current.currentTime = 0;
+            finRef.current.loop = false;
+        }
+    };
+
+    // Stop audio when the user navigates away from the page
+    useEffect(() => {
+        return () => stopCompletionSound();
+    }, []);
+
     useEffect(()=>{
         let interval;
 
@@ -20,7 +33,6 @@ const Pomodoro = () => {
                         clearInterval(interval);
                         setTimeLeft(25*60);
                         setIsRunning(false);
-                        finRef.current.loop = true;
                         finRef.current.play();
                         setShowPopUp(true);
                         return 0;
@@ -79,7 +91,7 @@ const Pomodoro = () => {
                         </button>
 
                         <button className='cursor-pointer btn btn-primary'
-                            onClick={()=>{setTimeLeft(25*60); setIsRunning(false)}}
+                            onClick={()=>{setTimeLeft(25*60); setIsRunning(false); stopCompletionSound(); setShowPopUp(false);}}
                         >
                             Reset
                         </button>


### PR DESCRIPTION
## 📌 Description

Fixed an issue in Focus Mode where the Pomodoro completion sound continued playing indefinitely after a session ended. The audio now stops correctly when the timer is reset or when the user navigates away from the page.

## 🔗 Related Issue

Closes #1495 

## 🛠 Changes Made

* Removed the infinite looping behavior of the Pomodoro completion sound.
* Added audio cleanup logic to stop and reset the sound when the component unmounts.
* Updated the Reset functionality to stop any active audio playback and reset the audio state.

## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors
* [x] Properly tested changes
* [x] Linked the issue

## 🚀 Notes for Reviewers

* This PR contains only the minimal changes required to fix the audio cleanup issue.
* No UI, styling, routing, backend, or dependency changes were made.
* Verified that audio stops correctly on timer reset and page navigation while preserving existing Pomodoro functionality.
