### PR TITLE
docs: add TWO_FACTOR_ENCRYPTION_KEY to env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 PORT=5000
 MONGO_URI=your_mongodb_atlas_connection_string
 JWT_SECRET=your_super_secret_key_here
+TWO_FACTOR_ENCRYPTION_KEY=your_64_character_hex_key_here # Must be a 32-byte hex key (64 hex characters)
 CLIENT_ORIGIN=your_deployed_frontend_url
 FRONTEND_URL=http://localhost:5173
 JWT_EXPIRES_IN=7d


### PR DESCRIPTION
## Description

Adds the missing `TWO_FACTOR_ENCRYPTION_KEY` environment variable to `backend/.env.example`.

This variable is required by the backend authentication setup but was not documented in the example environment configuration, which can cause setup issues for contributors following the documented installation process.

## Related Issue

Closes #1609

## Changes Made

* Added `TWO_FACTOR_ENCRYPTION_KEY` to `backend/.env.example`
* Added a descriptive placeholder value and format guidance

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My branch follows the naming convention
* [x] No unrelated files were modified
* [x] Change is limited to the scope of Issue #1609
