### PR TITLE
Fix #1398: Delete specific task instance in RoutineBuilder by checking

### DIFF
--- a/frontend/src/components/Routine/WeeklyGrid.jsx
+++ b/frontend/src/components/Routine/WeeklyGrid.jsx
@@ -63,7 +63,7 @@ function DroppableCell({ day, time, tasks, onDeleteTask }) {
           <button
             onClick={(e) => {
               e.stopPropagation(); // prevents drag from triggering
-              onDeleteTask(task.taskId, task.day);
+              onDeleteTask(task.taskId, task.day, task.startTime);
             }}
             className="absolute right-1 top-1/2 -translate-y-1/2 w-4 h-4 rounded-full 
              bg-red-500 text-white text-[9px] font-bold

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -184,7 +184,7 @@ export default function RoutineBuilder() {
 
   /* ---------------- DRAG END HANDLER ---------------- */
   // Removing Schedule task after drag
-  const removeScheduledTask = (taskId, day) => {
+  const removeScheduledTask = (taskId, day, startTime) => {
 
     //filtering out 
     setScheduledTasks((prev) =>
@@ -192,7 +192,8 @@ export default function RoutineBuilder() {
         (task) =>
           !(
             task.taskId === taskId &&
-            normalizeDay(task.day) === normalizeDay(day)
+            normalizeDay(task.day) === normalizeDay(day) &&
+            task.startTime === startTime
           )
       )
     );


### PR DESCRIPTION
## Description
This PR resolves [#1398](https://github.com/aryandas2911/DailyForge/issues/1398), where clicking the delete button on a specific scheduled task instance in the Routine Builder was mistakenly deleting all instances of that task on the same day.

### Changes Made
- Modified `WeeklyGrid.jsx` to pass the `task.startTime` into the `onDeleteTask` event handler, rather than just the `taskId` and `day`.
- Updated the `removeScheduledTask` function in `RoutineBuilder.jsx` to accept `startTime` and include it in the `.filter()` logic.
- The `removeScheduledTask` function now successfully targets and deletes *only* the specific task occurring at the precise time slot clicked by the user.

### Testing
- Dragged a "Read" task to Monday 9:00 AM and Monday 10:00 AM.
- Clicked delete on the 10:00 AM task.
- Verified that only the 10:00 AM task was removed, while the 9:00 AM task correctly remained in the grid.