### PR TITLE
Fix: "Create your first routine" CTA opens Task form instead of starting routine flow

### DIFF
--- a/frontend/src/components/Routine/WeeklyGrid.jsx
+++ b/frontend/src/components/Routine/WeeklyGrid.jsx
@@ -80,10 +80,22 @@ function DroppableCell({ day, time, tasks, onDeleteTask }) {
 }
 
 /* ---------------- Weekly Grid ---------------- */
-export default function WeeklyGrid({ scheduledTasks, onSaveDay, onDeleteTask, innerRef }) {
+export default function WeeklyGrid({ scheduledTasks, onSaveDay, onDeleteTask, innerRef, highlight }) {
   return (
-    <div className="card card-primary !pl-2.5 !pr-2.5 !py-3 animate-in" ref={innerRef}>
-      <h2 className="text-lg font-semibold text-main mb-4 px-6.5 pt-3">Weekly Schedule</h2>
+    <div
+      className={`card card-primary !pl-2.5 !pr-2.5 !py-3 animate-in transition-shadow duration-500 ${
+        highlight ? "ring-2 ring-cyan-400 shadow-[0_0_0_6px_rgba(34,211,238,0.15)]" : ""
+      }`}
+      ref={innerRef}
+    >
+      <h2 className="text-lg font-semibold text-main mb-1 px-6.5 pt-3">Weekly Schedule</h2>
+      {highlight ? (
+        <p className="text-xs text-cyan-600 dark:text-cyan-400 px-6.5 mb-3 animate-pulse">
+          Drag a task from your library onto the grid to start building a routine
+        </p>
+      ) : (
+        <div className="mb-3" />
+      )}
 
       <div
         className="grid w-full overflow-x-auto sm:overflow-visible"

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -43,6 +43,7 @@ export default function RoutineBuilder() {
   const [isImageExporting, setIsImageExporting] = useState(false);
   const [isTemplateModalOpen, setIsTemplateModalOpen] = useState(false);
   const [selectedTemplateDay, setSelectedTemplateDay] = useState("Monday");
+  const [highlightGrid, setHighlightGrid] = useState(false);
   const gridRef = useRef(null);
  
 
@@ -79,6 +80,27 @@ export default function RoutineBuilder() {
   const closeModal = useCallback(() => setIsModalOpen(false), []);
 
   const handleOpenModal = useScrollThenOpen(openModal, 0);
+
+  // Triggered by the "Saved Routines" empty state CTA.
+  // A routine is built by scheduling existing tasks onto the grid, so this
+  // should never open the Task form — that form already has its own CTA in
+  // the Task Library's empty state. Instead:
+  //  - if the library already has tasks, scroll up and pulse the grid so the
+  //    user sees where to drag tasks from
+  //  - if the library is empty too, open the Task form, since the user needs
+  //    at least one task before they can schedule anything
+  const pulseGrid = useScrollThenOpen(() => {
+    setHighlightGrid(true);
+    setTimeout(() => setHighlightGrid(false), 1600);
+  }, 0);
+
+  const handleStartRoutine = useCallback(() => {
+    if (tasks?.length > 0) {
+      pulseGrid();
+    } else {
+      handleOpenModal();
+    }
+  }, [tasks, pulseGrid, handleOpenModal]);
 
   const handleSubmit = async (data) => {
     try {
@@ -294,6 +316,7 @@ export default function RoutineBuilder() {
               onSaveDay={openSaveRoutineModal}
               onDeleteTask={removeScheduledTask}
               innerRef={gridRef}
+              highlight={highlightGrid}
             />
           </section>
         </div>
@@ -308,13 +331,14 @@ export default function RoutineBuilder() {
             <p className="text-sm text-muted">Loading routines…</p>
           ) : savedRoutines.length === 0 ? (
             /*
-             * EmptyState is deep in the page — clicking "Create Your First
-             * Routine" here triggers handleOpenModal, which scrolls to the
-             * top first, then opens the modal once the scroll settles.
+             * EmptyState is deep in the page. Clicking "Create Your First
+             * Routine" should guide the user toward the actual routine flow
+             * (drag a task onto the weekly grid), not open the Task form —
+             * that form belongs to the Task Library's own empty state.
              */
             <EmptyState
               type="routines"
-              onAction={handleOpenModal}
+              onAction={handleStartRoutine}
             />
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
## 📌 Description
On an empty Routine Builder page, clicking "+ Create your first routine" opened the Task creation modal (Title, Priority, Due Date, Repeat, etc.) instead of starting the actual routine-building flow, since the empty state's CTA was wired to the same handler used for adding tasks to the library. This PR fixes that by giving the routine empty-state CTA its own logic: if the user already has tasks to work with, it scrolls up and highlights the weekly grid to guide them toward drag-and-drop scheduling; only if their task library is empty does it fall back to opening the Task form, since a task is needed before anything can be scheduled. 
## 🔗 Related Issue
Closes #1563

## 🛠 Changes Made
- RoutineBuilder.jsx: added handleStartRoutine, which branches on whether the task library has tasks pulses/highlights the  grid if so, opens the Task modal if not
- RoutineBuilder.jsx: added highlightGrid state, passed to WeeklyGrid as a highlight prop
- RoutineBuilder.jsx: rewired the "Saved Routines" empty state onAction from handleOpenModal to handleStartRoutine
- WeeklyGrid.jsx: accepts new highlight prop shows a cyan ring/glow and a short inline hint ("Drag a task from your library onto the grid to start building a routine") when active
- No backend or schema changes; the existing Save Routine flow (Name + Description) was already correct

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
This issue originally described the routine creation form collecting task fields (Priority, Due Date, Repeat), but after digging in I found that form belongs to TaskFormModal (task creation) the actual routine save flow already only asks for Name + Description, which was correct. The real bug was narrower: the "Create your first routine" empty state button was wired to open that same Task form instead of guiding the user toward the drag and drop scheduling flow, so this PR fixes that specific wiring. I left a comment on the issue explaining the re scope before starting work, happy to adjust if you'd rather handle it differently. Verified with eslint and a production build (both clean), but wasn't able to do a full manual click-through locally due to local env setup issues, so flagging that in case you'd like to test the highlight/pulse behavior yourself before merging.
