### PR TITLE
feat: show LandingPage on / instead of Login (#1345)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,11 +37,7 @@ const AnimatedRoutes = () => {
         <Route
           path="/"
           element={
-            <PublicRoute>
-              <AuthLayout>
-                <Login />
-              </AuthLayout>
-            </PublicRoute>
+            <LandingPage />
           }
         />
         <Route
@@ -170,11 +166,7 @@ const App = () => {
           <Route
             path="/"
             element={
-              <PublicRoute>
-                <AuthLayout>
-                  <Login />
-                </AuthLayout>
-              </PublicRoute>
+              <LandingPage />
             }
           />
           <Route


### PR DESCRIPTION
## Summary
Closes #1345

Currently, the "/" route redirected users directly to the Login page, 
creating a poor first impression.

This PR fixes that by routing "/" to the existing `LandingPage.jsx` 
component instead of `<Login />`.

## Changes Made
- `App.jsx`: Changed the `"/"` route (in both `App` and `AnimatedRoutes`) 
  to render `<LandingPage />` instead of `<Login />`

## What the Landing Page includes
- Hero section with CTA buttons (Get Started / Login)
- Features section (Smart Task Management, Visual Routine Builder, 
  Productivity Insights)
- Final CTA section
- Fully responsive design
- Dark mode support

## How to Test
1. Run the app locally
2. Open `http://localhost:5173/`
3. You should now see the Landing Page instead of Login
4. Clicking "Get Started" → goes to `/signup`
5. Clicking "Login" → goes to `/login`

## Type of Change
- [x] New feature (non-breaking change)