### PR TITLE
Fix:  environment variable validation for MONGO_URI and JWT_SECRET

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,7 +16,28 @@ const PORT = process.env.PORT;
 
 // Initialize express     
 const app = express();
+const requiredEnv = ["MONGO_URI", "JWT_SECRET"];
 
+//env validation 
+const missing = requiredEnv.filter((key) => !process.env[key]);
+
+if (missing.length) {
+  console.error(
+    `[FATAL] Missing required environment variables: ${missing.join(", ")}`
+  );
+  console.error(
+    "Copy backend/.env.example to backend/.env and fill in the values."
+  );
+  process.exit(1);
+}
+
+if (process.env.JWT_SECRET.length < 32) {
+  console.error(
+    "[FATAL] JWT_SECRET must be at least 32 characters long."
+  );
+  console.error("Generate one with: openssl rand -hex 32");
+  process.exit(1);
+}
 
 app.use(
   cors({


### PR DESCRIPTION
## 📌 Description
I added validations for JWT_SECRET and MONGO_URI using filter method.

## 🔗 Related Issue
Closes #1671 

## 🛠 Changes Made
- Added validations in server.js file for JWT_SECRET and MONGO_URI
- 
- 


## ✅ Checklist
- [✅ ] Code runs locally
- [ ✅] Followed project structure
- [ ] No console errors
- [ ✅] Properly tested changes
- [ ✅] Linked the issue

## 🚀 Notes for Reviewers
While setting up the project, I noticed that TWO_FACTOR_ENCRYPTION_KEY is required by authController.js, but it is not documented in .env.example.

As a result, a fresh clone of the project fails to start until contributors manually discover and add this environment variable. It may be worth adding it to .env.example or handling its validation during application startup instead of at the module level .
  