### PR TITLE
clean up routine task references upon task deletion

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -329,6 +329,18 @@ export const deleteTask = async (req, res) => {
       });
     }
 
+    // Clean up routine task references
+    await Routine.updateMany(
+      { userId },
+      {
+        $pull: {
+          items: {
+            taskId: taskId,
+          },
+        },
+      }
+    );
+
     return res.status(200).json({
       success: true,
       message: "Task deleted successfully",


### PR DESCRIPTION
### Description
When a single task is deleted via the `deleteTask` controller, the backend deletes the task from the database but leaves its ID referenced inside any `Routine` models that used it. This leads to orphaned task references inside routines, resulting in database integrity errors.

This PR updates the `deleteTask` handler to pull the deleted task's ID from the `items` array of the `Routine` collection, ensuring referential integrity (matching the cleanup behavior of `bulkDeleteTasks`).

### Changes Made
- Added a `Routine.updateMany` with a `$pull` operation in `backend/controllers/taskController.js` to remove references to the deleted task ID.

### Verification & Testing
- Ran backend linter: `npm run lint` (Passed)
- Ran backend unit tests: `npm run test` (Passed)

