### PR TITLE
hide remaining time countdown for completed tasks

### DIFF
--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -136,7 +136,7 @@ export default function TaskPreview({ tasks , updateTask}) {
                   )}
 
                   {/*Disply Remaining Time */}
-                  {task.dueDate && (
+                  {task.dueDate && task.status !== "Completed" && (
                     <span className="text-[11px] text-red-500 font-medium">
                       {isOverdue 
                         ? "Overdue"


### PR DESCRIPTION
### Description
On the Dashboard's `TaskPreview` card, the remaining time/countdown was displayed even for tasks already marked as `"Completed"`. A completed task should not display remaining time or show "Overdue" status.

This PR updates the remaining time condition in the component to check that the task status is not `"Completed"`.

### Changes Made
- Modified `frontend/src/components/Dashboard/TaskPreview.jsx` to verify that `task.status !== "Completed"` before rendering the countdown or overdue text.

### Verification & Testing
- Ran frontend linter: `npm run lint` (Passed)

