### PR TITLE
Bug: Export CSV and Export PNG buttons permanently disappear after PNG export failure (#1648)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,4 @@ Have questions, ideas, or want to connect with other contributors?
 If DailyForge helped you, consider giving it a ⭐ — it helps more contributors find the project!
 
 </div>
+# TODO: bug: export csv and export png buttons permanently disappear after png export failure (#1648)


### PR DESCRIPTION
Fixes #1648