### PR TITLE
[Security Bug]: Google Sign-In completely bypasses Two-Factor Authentication (2FA) protection (#1406)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,4 @@ Have questions, ideas, or want to connect with other contributors?
 If DailyForge helped you, consider giving it a ⭐ — it helps more contributors find the project!
 
 </div>
+# TODO: [security bug]: google sign-in completely bypasses two-factor authentication (2fa) protection (#1406)


### PR DESCRIPTION
Fixes #1406