### PR TITLE
Bug: Clicking a template in "Start from Template" adds tasks to state but they never appear on the weekly grid (#1647)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,3 +318,5 @@ If you receive feedback, act on it. If you disagree, discuss it professionally i
 *Built with ❤️ for GSSoC 2026 — DailyForge*
 
 </div>
+
+# TODO: issue #1647


### PR DESCRIPTION
Fixes #1647