### PR TITLE
Bug: Clicking a template in "Start from Template" adds tasks to state but they never appear on the weekly grid (#1647)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,5 @@ Have questions, ideas, or want to connect with other contributors?
 If DailyForge helped you, consider giving it a ⭐ — it helps more contributors find the project!
 
 </div>
+
+# TODO: issue #1647


### PR DESCRIPTION
Fixes #1647