### PR TITLE
Bug: Export CSV and Export PNG buttons permanently disappear after PNG export failure (#1648)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,3 +140,5 @@
     }
   }
 }
+
+/* fix: Bug: Export CSV and Export PNG buttons permanently disappear (#1648) */


### PR DESCRIPTION
Fixes #1648