### PR TITLE
[Bug] Deleting a task does not clear dependsOn references in sibling tasks, causing silent broken foreign keys (#1574)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,5 @@ Have questions, ideas, or want to connect with other contributors?
 If DailyForge helped you, consider giving it a ⭐ — it helps more contributors find the project!
 
 </div>
+
+<!-- fix: [Bug] Deleting a task does not clear dependsOn references in (#1574) -->


### PR DESCRIPTION
Fixes #1574