### PR TITLE
bug: `default: []` in Task schema is a rogue top-level field, not the default value for `tags` (#1500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,5 @@ Have questions, ideas, or want to connect with other contributors?
 If DailyForge helped you, consider giving it a ⭐ — it helps more contributors find the project!
 
 </div>
+
+# TODO: fix for #1500: bug: `default: []` in Task schema is a rogue top-level field, not the default va


### PR DESCRIPTION
Fixes #1500