### PR TITLE
[Security Bug]: Google Sign-In completely bypasses Two-Factor Authentication (2FA) protection (#1406)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,5 @@ Have questions, ideas, or want to connect with other contributors?
 If DailyForge helped you, consider giving it a ⭐ — it helps more contributors find the project!
 
 </div>
+
+# TODO: security - [Security Bug]: Google Sign-In completely bypasses Two-Facto (#1406)


### PR DESCRIPTION
Fixes #1406