### PR TITLE
fix: make CORS origin configurable via CLIENT_ORIGIN env var (#1670)

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,14 +18,16 @@ const PORT = process.env.PORT;
 const app = express();
 
 
+const ALLOWED_ORIGINS = [
+  "http://localhost:5173",
+  "http://127.0.0.1:5173",
+];
+if (process.env.CLIENT_ORIGIN) {
+  ALLOWED_ORIGINS.push(process.env.CLIENT_ORIGIN);
+}
 app.use(
   cors({
-    origin: [
-      "https://dailyforge-frontend-lhjq.onrender.com",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-      process.env.CLIENT_ORIGIN,
-    ].filter(Boolean), 
+    origin: ALLOWED_ORIGINS,
     credentials: true,
   })
 );


### PR DESCRIPTION
Replaces the hardcoded Render URL with `CLIENT_ORIGIN` environment variable, falling back to localhost origins for development.

Fixes #1670