### PR TITLE
fix: reset password redirect URL issue

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -236,7 +236,11 @@ export const forgotPasswordRequest = async (req, res) => {
       });
 
       // Construct the reset URL for the frontend
-      const resetUrl = `${process.env.FRONTEND_URL}/reset-password?token=${resetToken}`;
+      const resetUrl = `${
+        process.env.NODE_ENV === 'production'
+        ? process.env.CLIENT_ORIGIN
+        : process.env.FRONTEND_URL || 'http://localhost:5173'
+      }/reset-password?token=${resetToken}`;
 
       const mailOptions = {
         to: user.email,


### PR DESCRIPTION
## Summary

Fixes the password reset URL generation to correctly redirect users based on the current environment.

### Changes Made

* Updated the password reset URL construction logic.
* Uses `CLIENT_ORIGIN` when running in **production**.
* Continues to use `FRONTEND_URL` (with a localhost fallback) during **development**.
* No other functionality or files were modified.

### Result

Password reset emails now contain the correct frontend URL in production, while preserving the existing development workflow.

Closes #1856 
