### PR TITLE
fix : attach Authorization header fallback for theme save requests (#1838)

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -10,6 +10,15 @@ const api = axios.create({
   },
 });
 
+// Attach auth token from localStorage as fallback for environments where cookies are not sent
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token && !config.headers.Authorization) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 // Handle response errors, including timeout
 api.interceptors.response.use(
   (response) => response, // success — pass through unchanged


### PR DESCRIPTION
## Summary of What Has Been Done

Added a request interceptor to the `api` axios instance that reads the authentication token from `localStorage` and attaches it as a `Bearer` authorization header when making API requests.

## Changes Made

- `frontend/src/api/axios.js`: Added `api.interceptors.request.use()` interceptor that reads `localStorage.getItem("token")` and sets `Authorization: Bearer <token>` header as a fallback for environments where cookies may not be sent with cross-origin requests.

## Impact it Made

- Resolves the "No token provided, please try again" error when saving theme settings in the Profile page
- Ensures authenticated API calls work reliably in all deployment environments (localhost and production)
- The interceptor is a belt-and-suspenders approach: it only adds the header if one is not already present, so it does not interfere with existing cookie-based auth

## Closes

Closes #1838

Note: Please assign this PR to the `tmdeveloper007` account.
