### PR TITLE
fix : make duration modal in TaskPreview dark-mode aware using theme variables (#1607)

### DIFF
--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -166,13 +166,13 @@ export default function TaskPreview({ tasks , updateTask}) {
       )}
 
       {durationModalTask && (
-        <div className="fixed inset-0 bg-black/10 flex items-center justify-center z-50 animate-in fade-in duration-200">
-          <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6">
-            <h2 className="text-xl font-semibold mb-2 text-black/90">
+        <div className="fixed inset-0 bg-black/20 dark:bg-black/50 flex items-center justify-center z-50 animate-in fade-in duration-200">
+          <div className="bg-(--surface) rounded-2xl shadow-xl w-full max-w-sm p-6">
+            <h2 className="text-xl font-semibold mb-2 text-main">
               Complete Task
             </h2>
 
-            <p className="text-sm mb-4 text-black">
+            <p className="text-sm mb-4 text-muted">
               How long did you actually take to complete "
               {durationModalTask.title}"?
             </p>
@@ -181,7 +181,7 @@ export default function TaskPreview({ tasks , updateTask}) {
               min="1"
               value={actualDuration}
               onChange={(e) => setActualDuration(e.target.value)}
-              className="w-full p-2 border border-soft rounded-lg text-black dark:placeholder-slate-500"
+              className="w-full p-2 border border-soft rounded-lg text-main bg-transparent dark:placeholder-slate-500"
               placeholder="Actual duration in minutes"
             />
             <div className="flex justify-end gap-3 mt-5">
@@ -190,7 +190,7 @@ export default function TaskPreview({ tasks , updateTask}) {
                   setDurationModalTask(null);
                   setActualDuration("");
                 }}
-                className="px-4 py-2 rounded-lg border border-soft text-black hover:bg-gray-100 transition"
+                className="px-4 py-2 rounded-lg border border-soft text-main hover:bg-(--surface)/80 transition"
               >
                 Cancel
               </button>


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced hardcoded light-mode color classes in the "Complete Task" duration modal with theme-aware CSS variable classes for proper dark mode support.

## Changes Made

- `frontend/src/components/Dashboard/TaskPreview.jsx`:
  - Modal backdrop: `bg-black/10` changed to `bg-black/20 dark:bg-black/50` for better contrast in both modes
  - Modal container: `bg-white` changed to `bg-(--surface)` (theme-aware surface color)
  - Modal heading: `text-black/90` changed to `text-main` (theme-aware text color)
  - Modal description: `text-black` changed to `text-muted` (theme-aware muted text)
  - Duration input: `text-black dark:placeholder-slate-500` changed to `text-main bg-transparent`
  - Cancel button: `text-black hover:bg-gray-100` changed to `text-main hover:bg-(--surface)/80`

## Impact it Made

- The "Complete Task" duration modal now respects the app's theme settings
- Modal is visually consistent with other modals in the app (uses `bg-(--surface)` and `text-main`)
- Backdrop is more visible in dark mode (`dark:bg-black/50`)
- No more jarring white modal in dark mode

## Closes

Closes #1607

Note: Please assign this PR to the `tmdeveloper007` account.
