### PR TITLE
chore : remove debug console.log and alert statements from useTasks hook

### DIFF
--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -52,7 +52,6 @@ const useTasks = ({
           limit: data.limit || initialLimit,
         });
       } catch (error) {
-        console.log(error?.response?.data?.message || "Failed to load tasks");
         setTasks([]);
       } finally {
         setLoading(false);
@@ -64,9 +63,7 @@ const useTasks = ({
   // create new task
   const addTask = async (taskData) => {
     try {
-      const response = await api.post("/tasks", taskData);
-
-      console.log("Task added:", response.data);
+      await api.post("/tasks", taskData);
 
       invalidateTasks();
 
@@ -76,13 +73,6 @@ const useTasks = ({
         setPage(DEFAULT_PAGE);
       }
     } catch (error) {
-      console.log("FULL ERROR:", error);
-      console.log(
-        error?.response?.data?.message ||
-          error?.response?.data ||
-          error.message,
-      );
-      alert(error?.response?.data?.message || "Failed to create task");
       throw error;
     }
   };
@@ -114,7 +104,6 @@ const useTasks = ({
       invalidateTasks();
       await getTasks(page);
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to update task");
       invalidateTasks();
       await getTasks(page);
     }


### PR DESCRIPTION
Closes #1883

## Summary of What Has Been Done

Removed all debug `console.log` statements and the disruptive `alert()` popup from `frontend/src/hooks/useTasks.js`.

## Changes Made

- Removed `console.log` in `getTasks` catch block
- Removed `console.log("Task added:", response.data)` after task creation
- Removed `console.log("FULL ERROR:", error)` and related log in `addTask` catch block
- Replaced `alert(error?.response?.data?.message || "Failed to create task")` with silent re-throw of the error (the caller already handles errors)
- Removed `console.log` in `updateTask` catch block

## Impact it Made

- Cleaner browser console for production users
- Removes disruptive `alert()` popup on task creation failure
- Reduces noise in developer debugging
- Improves user experience during task operations

Note: Please assign this PR to the `tmdeveloper007` account.