### PR TITLE
fix : apply dark mode ring color and text to tag selection buttons in TaskFormModal

### DIFF
--- a/frontend/src/components/Task/TaskFormModal.jsx
+++ b/frontend/src/components/Task/TaskFormModal.jsx
@@ -339,8 +339,8 @@ import FormError from "../common/FormError";
                         disabled={isSubmitting}
                         className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
                           isSelected
-                            ? "ring-2 ring-offset-1"
-                            : "opacity-60 hover:opacity-100"
+                            ? "ring-2 ring-offset-1 ring-indigo-500 dark:ring-indigo-400"
+                            : "opacity-60 hover:opacity-100 text-slate-700 dark:text-slate-300"
                         }`}
                       >
                         {tag}


### PR DESCRIPTION
Closes #1884

## Summary of What Has Been Done

Added proper dark mode ring color and text color to the tag selection buttons in `frontend/src/components/Task/TaskFormModal.jsx`.

## Changes Made

- Added `ring-indigo-500 dark:ring-indigo-400` to selected tag buttons so the ring is visible in both light and dark mode
- Added `text-slate-700 dark:text-slate-300` to unselected tag buttons for better contrast in dark mode

## Impact it Made

- Tag selection ring is clearly visible in dark mode (previously used browser-default ring color)
- Unselected tag labels have proper contrast in dark mode, fixing low-visibility issue
- Consistent dark mode experience when creating or editing tasks

Note: Please assign this PR to the `tmdeveloper007` account.