### PR TITLE
feat : persist ForgeMode soundscape volume to localStorage

### DIFF
--- a/frontend/src/pages/ForgeMode.jsx
+++ b/frontend/src/pages/ForgeMode.jsx
@@ -35,7 +35,10 @@ export default function ForgeMode() {
   
   // Ambient audio state
   const [currentSound, setCurrentSound] = useState("none");
-  const [volume, setVolume] = useState(0.5);
+  const [volume, setVolume] = useState(() => {
+    const saved = localStorage.getItem("forgeMode_volume");
+    return saved !== null ? Number(saved) : 0.5;
+  });
   const [isMuted, setIsMuted] = useState(false);
   const [soundscapeMenuOpen, setSoundscapeMenuOpen] = useState(false);
   
@@ -168,6 +171,11 @@ export default function ForgeMode() {
       audioRef.current.volume = isMuted ? 0 : volume;
     }
   }, [volume, isMuted, currentSound]);
+
+  // Persist volume preference to localStorage
+  useEffect(() => {
+    localStorage.setItem("forgeMode_volume", String(volume));
+  }, [volume]);
 
   // Format MM:SS
   const formatTime = (secs) => {


### PR DESCRIPTION
Closes #1885

## Summary of What Has Been Done

Added localStorage persistence for the ForgeMode soundscape volume preference.

## Changes Made

- Modified the `volume` state initialization to read from `localStorage.getItem("forgeMode_volume")` if a saved value exists, defaulting to `0.5`
- Added a `useEffect` that writes the volume value to `localStorage.setItem("forgeMode_volume", volume)` whenever the volume state changes

## Impact it Made

- Users no longer need to adjust their preferred volume every time they enter ForgeMode
- Better UX continuity across page navigation and browser sessions
- Minor but meaningful quality-of-life improvement for frequent ForgeMode users

Note: Please assign this PR to the `tmdeveloper007` account.