### PR TITLE
fix : add dark mode text color to Dashboard tag modal inputs and labels

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -618,11 +618,11 @@ export default function Dashboard() {
             className="bg-(--surface) p-6 rounded-xl w-[400px]"
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="text-lg font-semibold mb-4">Select Tags</h3>
+            <h3 className="text-lg font-semibold mb-4 text-main">Select Tags</h3>
 
             <div className="space-y-2">
               {availableTags.map((tag) => (
-                <label key={tag} className="flex items-center gap-2">
+                <label key={tag} className="flex items-center gap-2 text-main">
                   <input
                     type="checkbox"
                     checked={selectedTags.includes(tag)}
@@ -646,7 +646,7 @@ export default function Dashboard() {
                 value={customTag}
                 onChange={(e) => setCustomTag(e.target.value)}
                 placeholder="Create custom tag"
-                className="flex-1 px-3 py-2 rounded-lg border dark:placeholder-slate-500"
+                className="flex-1 px-3 py-2 rounded-lg border border-soft bg-transparent text-main dark:bg-slate-800 dark:placeholder-slate-500 dark:text-white"
               />
 
               <button


### PR DESCRIPTION
Closes #1886

## Summary of What Has Been Done

Added missing `text-main` dark mode color class to the inline tag modal in `frontend/src/pages/Dashboard.jsx`, which is shown when users select tags from their profile.

## Changes Made

- Added `text-main` to the "Select Tags" heading for proper dark mode text color
- Added `text-main` to each tag label checkbox so labels are readable in dark mode
- Added full dark mode styling (`border-soft`, `bg-transparent`, `dark:bg-slate-800`, `dark:text-white`, `dark:placeholder-slate-500`) to the custom tag text input

## Impact it Made

- Tag labels and the custom tag input are now readable in dark mode
- The inline tag selection modal now respects the app theme consistently with other components
- Prevents invisible or low-contrast tag labels when users open the tag modal in dark mode

Note: Please assign this PR to the `tmdeveloper007` account.