### PR TITLE
feat : added copy routine name to clipboard in routine cards

### DIFF
--- a/frontend/src/components/Routine/RoutineCard.jsx
+++ b/frontend/src/components/Routine/RoutineCard.jsx
@@ -59,6 +59,18 @@ export default function RoutineCard({
     }
   };
 
+  const handleCopyName = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      await navigator.clipboard.writeText(routine.name);
+      triggerToast("Name Copied", `${routine.name} copied to clipboard.`);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to copy routine name");
+    }
+  };
+
   const handleExportPDF = async (e) => {
     e.stopPropagation();
     setShowMenu(false);
@@ -415,6 +427,13 @@ export default function RoutineCard({
               >
                 <Share2 size={16} />
                 Copy Share Link
+              </button>
+              <button
+                onClick={handleCopyName}
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer"
+              >
+                <Copy size={16} />
+                Copy Name
               </button>
               <button
                 onClick={handleCopySummary}

--- a/frontend/src/components/Routine/RoutineOverviewModal.jsx
+++ b/frontend/src/components/Routine/RoutineOverviewModal.jsx
@@ -57,6 +57,18 @@ export default function RoutineOverviewModal({
     }
   };
 
+  const handleCopyName = async (e) => {
+    e.stopPropagation();
+    setShowMenu(false);
+    try {
+      await navigator.clipboard.writeText(routine.name);
+      triggerToast("Routine name copied!");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to copy routine name");
+    }
+  };
+
   const handleExportPDF = async (e) => {
     e.stopPropagation();
     setShowMenu(false);
@@ -146,6 +158,13 @@ export default function RoutineOverviewModal({
                 >
                   <Share2 size={16} />
                   Copy Share Link
+                </button>
+                <button
+                  onClick={handleCopyName}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-main hover:bg-slate-100 dark:hover:bg-slate-800 transition font-medium cursor-pointer"
+                >
+                  <Copy size={16} />
+                  Copy Name
                 </button>
                 <button
                   onClick={handleCopySummary}


### PR DESCRIPTION
## Summary of What Has Been Done

Added a "Copy Name" option to the routine card menu and routine overview modal menu. Clicking it copies the routine name text to the clipboard and shows a toast confirmation.

## Changes Made

1. `frontend/src/components/Routine/RoutineCard.jsx`:
   - Added `handleCopyName` async function that writes `routine.name` to clipboard and shows a toast
   - Added "Copy Name" menu button with a Copy icon between "Copy Share Link" and "Copy Summary"
2. `frontend/src/components/Routine/RoutineOverviewModal.jsx`:
   - Added `handleCopyName` async function
   - Added "Copy Name" menu button in the modal's options menu

## Impact it Made

Users can quickly copy a routine's name for use in external tools (spreadsheets, documents, etc.) without needing to manually select text.

Closes #1893

Note: Please assign this PR to the `tmdeveloper007` account.