### PR TITLE
feat : added health check endpoint for backend server

### DIFF
--- a/backend/routes/healthRoutes.js
+++ b/backend/routes/healthRoutes.js
@@ -1,0 +1,11 @@
+import express from "express";
+
+export const healthRouter = express.Router();
+
+// GET /health - public health check endpoint for monitoring tools
+healthRouter.get("/", (req, res) => {
+  res.status(200).json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+  });
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,6 +11,7 @@ import { taskRouter } from "../routes/taskRoutes.js";
 import { routineRouter } from "../routes/routineRoutes.js";
 import { analyticsRouter } from "../routes/analyticsRoutes.js";
 import { journalRouter } from "../routes/journalRoutes.js";
+import { healthRouter } from "../routes/healthRoutes.js";
 import { validateEnv } from "../utils/envValidator.js";
 import connectCloudinary from "../config/cloudinary.js";
 import { rateLimit } from "express-rate-limit";
@@ -79,6 +80,9 @@ app.use("/api/analytics", analyticsRouter);
 
 // Router for accessing journal routes
 app.use("/api/journal", journalRouter);
+
+// Health check endpoint for monitoring tools
+app.use("/health", healthRouter);
 
 app.get("/", (req, res) => {
   res.send("Server running");


### PR DESCRIPTION
## Summary of What Has Been Done

Added a public `GET /health` endpoint to the backend that returns a JSON response with the server status and a timestamp.

## Changes Made

1. Created `backend/routes/healthRoutes.js`:
   - `GET /` returns `{ status: "ok", timestamp: "<ISO timestamp>" }` with HTTP 200
   - No authentication required (public endpoint for monitoring tools)
2. Updated `backend/src/server.js`:
   - Imported `healthRouter` from the new routes file
   - Mounted it at the `/health` path

## Impact it Made

- Enables uptime monitoring tools (e.g., healthchecks.io, Pingdom) to verify backend availability
- Allows load balancers and reverse proxies to perform health checks
- Provides a lightweight diagnostics endpoint for debugging and observability

Closes #1894

Note: Please assign this PR to the `tmdeveloper007` account.