### PR TITLE
feat : added per-day and full-schedule reset buttons to Routine Builder

### DIFF
--- a/frontend/src/components/Routine/WeeklyGrid.jsx
+++ b/frontend/src/components/Routine/WeeklyGrid.jsx
@@ -1,5 +1,5 @@
 import { useDroppable } from "@dnd-kit/core";
-import { Save } from "lucide-react";
+import { Save, RotateCcw } from "lucide-react";
 
 /* ---------------- Constants ---------------- */
 const DAYS = [
@@ -80,7 +80,7 @@ function DroppableCell({ day, time, tasks, onDeleteTask }) {
 }
 
 /* ---------------- Weekly Grid ---------------- */
-export default function WeeklyGrid({ scheduledTasks, onSaveDay, onDeleteTask, innerRef, highlight }) {
+export default function WeeklyGrid({ scheduledTasks, onSaveDay, onDeleteTask, onResetDay, innerRef, highlight }) {
   return (
     <div
       className={`card card-primary !pl-2.5 !pr-2.5 !py-3 animate-in transition-shadow duration-500 ${
@@ -106,7 +106,7 @@ export default function WeeklyGrid({ scheduledTasks, onSaveDay, onDeleteTask, in
         {/* ===== Save Buttons Row ===== */}
         <div /> {/* empty time column */}
         {DAYS.map((day) => (
-          <div key={`save-${day}`} className="flex justify-center pb-2">
+          <div key={`save-${day}`} className="flex justify-center items-center gap-1.5 pb-2">
             <button
               onClick={() => onSaveDay(day)}
               title={`Save ${day} Routine`}
@@ -114,6 +114,13 @@ export default function WeeklyGrid({ scheduledTasks, onSaveDay, onDeleteTask, in
             >
               <Save size={10} className="sm:w-3 sm:h-3" />
               <span className="hidden sm:inline">Save</span>
+            </button>
+            <button
+              onClick={() => onResetDay(day)}
+              title={`Reset ${day}`}
+              className="flex items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-slate-700 p-1 cursor-pointer hover:bg-red-50 dark:hover:bg-red-950/30 hover:border-red-200 dark:hover:border-red-800 hover:text-red-500 transition-all duration-200"
+            >
+              <RotateCcw size={9} className="sm:w-2.5 sm:h-2.5" />
             </button>
           </div>
         ))}

--- a/frontend/src/pages/RoutineBuilder.jsx
+++ b/frontend/src/pages/RoutineBuilder.jsx
@@ -206,6 +206,14 @@ export default function RoutineBuilder() {
     setIsSaveModalOpen(true);
   };
 
+  const handleResetDay = (day) => {
+    setScheduledTasks((prev) => prev.filter((task) => task.day !== day));
+  };
+
+  const handleResetAll = () => {
+    setScheduledTasks([]);
+  };
+
   /* ---------------- DRAG END HANDLER ---------------- */
   // Removing Schedule task after drag
   const removeScheduledTask = (taskId, day, startTime) => {
@@ -289,6 +297,12 @@ export default function RoutineBuilder() {
             {isImageExporting ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
             {isImageExporting ? "Exporting..." : "Export as PNG"}
           </button>
+          <button
+            onClick={handleResetAll}
+            className="btn btn-secondary flex items-center gap-2 cursor-pointer hover-lift border border-gray-300 px-4 py-2 rounded-lg"
+          >
+            Reset All
+          </button>
           <div className="flex items-center gap-3">
             <button
             onClick={() => setIsTemplateModalOpen(true)}
@@ -318,6 +332,7 @@ export default function RoutineBuilder() {
               scheduledTasks={scheduledTasks}
               onSaveDay={openSaveRoutineModal}
               onDeleteTask={removeScheduledTask}
+              onResetDay={handleResetDay}
               innerRef={gridRef}
               highlight={highlightGrid}
             />


### PR DESCRIPTION
## Summary of What Has Been Done

Added per-day reset buttons and a global "Reset All" button to the Routine Builder to allow users to quickly clear scheduled tasks without losing the entire grid.

## Changes Made

1. `frontend/src/pages/RoutineBuilder.jsx`:
   - Added `handleResetDay(day)` function that filters out all tasks for a given day from `scheduledTasks`
   - Added `handleResetAll()` function that clears all `scheduledTasks`
   - Added "Reset All" button in the header next to the "Export as PNG" button
   - Passed `handleResetDay` as `onResetDay` prop to `WeeklyGrid`
2. `frontend/src/components/Routine/WeeklyGrid.jsx`:
   - Imported `RotateCcw` from `lucide-react`
   - Added `onResetDay` to the component props
   - Added a small reset (RotateCcw) icon button next to each day's "Save" button in the header row

## Impact it Made

Users can experiment freely with scheduling without fear of being stuck with a messy grid. Individual day resets let users fix just one column, while "Reset All" clears the entire week at once.

Closes #1896

Note: Please assign this PR to the `tmdeveloper007` account.