### PR TITLE
fix : added dark mode text color to LiveClock component

### DIFF
--- a/frontend/src/components/Dashboard/LiveClock.jsx
+++ b/frontend/src/components/Dashboard/LiveClock.jsx
@@ -24,7 +24,7 @@ const LiveClock = () => {
   }, []);
 
   return (
-    <p className="text-sm text-teal-500 mt-2">
+    <p className="text-sm text-teal-500 dark:text-teal-400 mt-2">
       {currentTime}
     </p>
   );


### PR DESCRIPTION
## Summary of What Has Been Done
Changed the `text-teal-500` class in LiveClock.jsx to `text-teal-500 dark:text-teal-400` to provide proper dark mode styling.

## Changes Made
- `frontend/src/components/Dashboard/LiveClock.jsx`: Added `dark:text-teal-400` variant to the clock text element.

## Impact it Made
- LiveClock component now renders correctly in dark mode with appropriate text color.

Closes #1914

## Note: Please assign this PR to the `tmdeveloper007` account.