### PR TITLE
fix : added aria-modal attributes and dark-mode styling to KeyboardShortcutsHelp modal

### DIFF
--- a/frontend/src/components/KeyboardShortcutsHelp.jsx
+++ b/frontend/src/components/KeyboardShortcutsHelp.jsx
@@ -9,23 +9,32 @@ const KeyboardShortcutsHelp = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50" role="presentation">
+      <div
+        className="surface-bg rounded-lg p-6 max-w-md w-full mx-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="keyboard-shortcuts-title"
+      >
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-semibold">Keyboard Shortcuts</h2>
-          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+          <h2 id="keyboard-shortcuts-title" className="text-lg font-semibold text-main">Keyboard Shortcuts</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close keyboard shortcuts help"
+            className="text-muted hover:text-main transition-colors cursor-pointer"
+          >
             &times;
           </button>
         </div>
         <div className="space-y-3">
           {shortcuts.map((shortcut, index) => (
             <div key={index} className="flex justify-between items-center">
-              <span className="text-gray-600 dark:text-gray-300">{shortcut.description}</span>
+              <span className="text-muted">{shortcut.description}</span>
               <div className="flex gap-1">
                 {shortcut.keys.map((key, keyIndex) => (
                   <kbd
                     key={keyIndex}
-                    className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-sm font-mono"
+                    className="px-2 py-1 bg-slate-100 dark:bg-slate-700 rounded text-sm font-mono text-main border border-soft"
                   >
                     {key}
                   </kbd>
@@ -34,8 +43,8 @@ const KeyboardShortcutsHelp = ({ isOpen, onClose }) => {
             </div>
           ))}
         </div>
-        <div className="mt-4 text-sm text-gray-500">
-          Press <kbd className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">?</kbd> to open this help
+        <div className="mt-4 text-sm text-muted">
+          Press <kbd className="px-1 py-0.5 bg-slate-100 dark:bg-slate-700 rounded border border-soft font-mono text-main">?</kbd> to open this help
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary of What Has Been Done
Added proper ARIA accessibility attributes to the `KeyboardShortcutsHelp` modal dialog and replaced hardcoded light-mode background colors with the project's CSS variable system.

## Changes Made
- Modified `frontend/src/components/KeyboardShortcutsHelp.jsx`:
  - Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="keyboard-shortcuts-title"` to the modal container.
  - Added `aria-label="Close keyboard shortcuts help"` to the close button.
  - Replaced `bg-white dark:bg-gray-800` with `surface-bg` for the modal background.
  - Added `backdrop-blur-sm` to the overlay for premium feel.
  - Replaced hardcoded background colors on `<kbd>` elements with `bg-slate-100 dark:bg-slate-700 border border-soft`.

## Impact it Made
- Improved accessibility for keyboard navigation and screen reader users (WCAG compliance).
- Modal now visually integrates with the DailyForge dark mode theme system.

Closes #1926
## Note: please assign this PR to the `tmdeveloper007` account.
