### PR TITLE
fix : removed emoji characters from Dashboard mood display

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,7 +2,7 @@ import OnboardingModal from "../components/OnboardingModal";
 import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext"; 
-import { CheckCircle2, Calendar, Flame, ArrowRight, RotateCw, Copy, BookOpen, Upload } from "lucide-react";
+import { CheckCircle2, Calendar, Flame, ArrowRight, RotateCw, Copy, BookOpen, Upload, Smile, Coffee, Meh, AlertTriangle, CloudRain, Zap, Moon } from "lucide-react";
 import LiveClock from "../components/Dashboard/LiveClock";
 import StatCard from "../components/Dashboard/StatCard";
 import TaskPreview from "../components/Dashboard/TaskPreview";
@@ -506,13 +506,13 @@ export default function Dashboard() {
                       <h2 className="text-lg font-semibold text-main text-left">Daily Journal</h2>
                     </div>
                     {todayJournal && (
-                      <span className="text-2xl" title={`Mood: ${todayJournal.mood}`}>
-                        {todayJournal.mood === "happy" ? "😃" :
-                          todayJournal.mood === "calm" ? "😌" :
-                            todayJournal.mood === "neutral" ? "😐" :
-                              todayJournal.mood === "stressed" ? "🤯" :
-                                todayJournal.mood === "sad" ? "😢" :
-                                  todayJournal.mood === "energetic" ? "⚡" : "😴"}
+                      <span title={`Mood: ${todayJournal.mood}`} className="text-main">
+                        {todayJournal.mood === "happy" ? <Smile size={24} className="text-green-500" /> :
+                          todayJournal.mood === "calm" ? <Coffee size={24} className="text-teal-500" /> :
+                            todayJournal.mood === "neutral" ? <Meh size={24} className="text-slate-400" /> :
+                              todayJournal.mood === "stressed" ? <AlertTriangle size={24} className="text-orange-500" /> :
+                                todayJournal.mood === "sad" ? <CloudRain size={24} className="text-blue-500" /> :
+                                  todayJournal.mood === "energetic" ? <Zap size={24} className="text-yellow-500" /> : <Moon size={24} className="text-indigo-500" />}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced emoji characters (😃, 😌, 😐, 🤯, 😢, ⚡, 😴) used for mood display in the Dashboard page with lucide-react SVG icon components.

## Changes Made

- Replaced emoji string literals in `frontend/src/pages/Dashboard.jsx` with lucide-react icon components
- Added imports: `Smile`, `Coffee`, `Meh`, `AlertTriangle`, `CloudRain`, `Zap`, `Moon` from lucide-react
- Each mood now renders an appropriate colored SVG icon (e.g., `Smile` for happy, `Coffee` for calm)
- Icons use color classes matching the mood (green for happy, teal for calm, etc.)

## Impact it Made

- Consistent emoji-free design aligned with the application's design standards
- Better cross-browser and cross-platform rendering of mood indicators
- Improved accessibility through SVG icons instead of emoji characters

Closes #1934

## Note: Please assign this PR to the `tmdeveloper007` account.