### PR TITLE
fix : added dark-mode-aware theming to TaskPreview duration modal

### DIFF
--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -167,12 +167,12 @@ export default function TaskPreview({ tasks , updateTask}) {
 
       {durationModalTask && (
         <div className="fixed inset-0 bg-black/10 flex items-center justify-center z-50 animate-in fade-in duration-200">
-          <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6">
-            <h2 className="text-xl font-semibold mb-2 text-black/90">
+          <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl w-full max-w-sm p-6">
+            <h2 className="text-xl font-semibold mb-2 text-main">
               Complete Task
             </h2>
 
-            <p className="text-sm mb-4 text-black">
+            <p className="text-sm mb-4 text-muted">
               How long did you actually take to complete "
               {durationModalTask.title}"?
             </p>
@@ -181,7 +181,7 @@ export default function TaskPreview({ tasks , updateTask}) {
               min="1"
               value={actualDuration}
               onChange={(e) => setActualDuration(e.target.value)}
-              className="w-full p-2 border border-soft rounded-lg text-black dark:placeholder-slate-500"
+              className="w-full p-2 border border-soft rounded-lg text-main dark:placeholder-slate-500 bg-white dark:bg-slate-700"
               placeholder="Actual duration in minutes"
             />
             <div className="flex justify-end gap-3 mt-5">
@@ -190,7 +190,7 @@ export default function TaskPreview({ tasks , updateTask}) {
                   setDurationModalTask(null);
                   setActualDuration("");
                 }}
-                className="px-4 py-2 rounded-lg border border-soft text-black hover:bg-gray-100 transition"
+                className="px-4 py-2 rounded-lg border border-soft text-main hover:bg-gray-100 dark:hover:bg-slate-700 transition"
               >
                 Cancel
               </button>


### PR DESCRIPTION
## Summary of What Has Been Done

Applied dark-mode-aware Tailwind classes to the TaskPreview duration-input modal dialog, replacing hardcoded light-mode-only styling.

## Changes Made

In `frontend/src/components/Dashboard/TaskPreview.jsx`:
- Modal container: `bg-white` changed to `bg-white dark:bg-slate-800`
- Modal heading: `text-black/90` changed to `text-main`
- Modal description text: `text-black` changed to `text-muted`
- Duration input: `text-black` changed to `text-main`, added `bg-white dark:bg-slate-700`
- Cancel button: `text-black` changed to `text-main`, `hover:bg-gray-100` changed to `hover:bg-gray-100 dark:hover:bg-slate-700`

## Impact it Made

- Modal dialog renders correctly with proper contrast in dark mode
- Consistent visual design across all modal dialogs in the application
- Improved dark mode user experience for the task completion flow

Closes #1936

## Note: Please assign this PR to the `tmdeveloper007` account.