### PR TITLE
fix : replaced alert call with toast notification in Tasks page duration validation

### DIFF
--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -141,7 +141,7 @@ export default function Tasks() {
     const durationValue = Number(actualDuration);
 
     if (Number.isNaN(durationValue) || durationValue <= 0) {
-      alert("Please enter a valid duration in minutes");
+      showToast("Please enter a valid duration in minutes", "error");
       return;
     }
 


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the blocking `alert()` call in `frontend/src/pages/Tasks.jsx` with the existing `showToast` notification system that was already present in the file.

## Changes Made

- `frontend/src/pages/Tasks.jsx`: replaced `alert("Please enter a valid duration in minutes")` with `showToast("Please enter a valid duration in minutes", "error")`

## Impact it Made

- Removes blocking `alert()` dialog from the task duration submission flow
- Uses the existing toast notification system for consistent, non-intrusive error feedback

Closes #1947.

## Note: please assign this PR to the `tmdeveloper007` account.
