### PR TITLE
fix : removed console.log exposing Firebase API key from firebase utils

### DIFF
--- a/frontend/src/utils/firebase.js
+++ b/frontend/src/utils/firebase.js
@@ -1,8 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 
-console.log("Firebase API Key:", import.meta.env.VITE_FIREBASE_API_KEY);
-
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the `console.log` statement from `frontend/src/utils/firebase.js` that was logging the Firebase API key value to the browser console.

## Changes Made

- `frontend/src/utils/firebase.js`: removed `console.log("Firebase API Key:", import.meta.env.VITE_FIREBASE_API_KEY);`

## Impact it Made

- Prevents sensitive Firebase configuration values from appearing in browser developer tools
- Improves security hygiene by eliminating unnecessary logging of environment variables

Closes #1948.

## Note: please assign this PR to the `tmdeveloper007` account.
