### PR TITLE
fix: make task due date clearly visible in list view

### DIFF
--- a/frontend/src/components/Task/TaskItem.jsx
+++ b/frontend/src/components/Task/TaskItem.jsx
@@ -235,12 +235,6 @@ export default function TaskItem({
                   {task.priority} priority
                 </span>
 
-                {task.dueDate && (
-                  <span className="flex items-center gap-1">
-                    <Calendar size={12} />
-                    {new Date(task.dueDate).toLocaleDateString()}
-                  </span>
-                )}
                 {isCompleted && task.actualDuration != null && (
                   <span>Actual: {task.actualDuration}m</span>
                 )}
@@ -266,6 +260,13 @@ export default function TaskItem({
                   </div>
                 )}
               </div>
+
+              {task.dueDate && (
+                <div className="flex items-center gap-1.5 mt-1.5 text-xs font-medium text-main">
+                  <Calendar size={13} className="opacity-70" />
+                  <span>Due: {new Date(task.dueDate).toLocaleDateString()}</span>
+                </div>
+              )}
             </div>
 
             {/* Actions */}


### PR DESCRIPTION
## Description

In the task list view, the due date was previously shown inline with other metadata using muted colors, making it easy to overlook. This fix moves the due date to its own line with a 'Due:' prefix so users can clearly see deadlines when prioritizing tasks.

## Changes
- Moved due date to a separate line in the list view layout
- Added 'Due:' label prefix for clarity
- Changed font weight to medium and color to text-main for better visibility
- Added Calendar icon with opacity for visual distinction

## Related Issues
Fixes #851