### PR TITLE
fix : added dark-mode-aware text color to LiveClock component

### DIFF
--- a/frontend/src/components/Dashboard/LiveClock.jsx
+++ b/frontend/src/components/Dashboard/LiveClock.jsx
@@ -24,7 +24,7 @@ const LiveClock = () => {
   }, []);
 
   return (
-    <p className="text-sm text-teal-500 mt-2">
+    <p className="text-sm text-teal-500 dark:text-[var(--primary)] mt-2">
       {currentTime}
     </p>
   );


### PR DESCRIPTION
## Summary of What Has Been Done

Updated the `LiveClock.jsx` component to use a dark-mode-aware text color for the live time display.

## Changes Made

1. Changed the Tailwind class from `text-teal-500` to `text-teal-500 dark:text-[var(--primary)]`.
2. In dark mode, the time text now uses the `--primary` CSS variable color, which matches the application's theme primary color and provides proper contrast.

## Impact it Made

- The live clock time is now readable and consistent in dark mode.
- Uses the established theme variable pattern (`--primary`) consistent with other components in the codebase.

## Note: please assign this PR to the `tmdeveloper007` account.
