### PR TITLE
fix : added dark-mode-aware styling to InsightCard list items

### DIFF
--- a/frontend/src/components/Dashboard/InsightCard.jsx
+++ b/frontend/src/components/Dashboard/InsightCard.jsx
@@ -1,12 +1,12 @@
 export default function InsightCard({ insights }) {
   return (
     <div className="bg-(--surface) rounded-xl shadow-md p-5">
-      <h2 className="text-lg font-semibold text-main mb-4">Insights</h2>
-      <ul className="space-y-3 text-sm text-main">
+      <h2 className="text-lg font-semibold text-main dark:text-white mb-4">Insights</h2>
+      <ul className="space-y-3 text-sm text-main dark:text-slate-200">
         {insights?.map((insight, i) => (
           <li key={i} className="flex items-start gap-2">
-            <span className="text-(--primary)">{insight.icon}</span>
-            <span>{insight.message}</span>
+            <span className="text-(--primary) shrink-0">{insight.icon}</span>
+            <span className="text-main dark:text-slate-200">{insight.message}</span>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary of What Has Been Done

Updated `InsightCard.jsx` to include explicit dark-mode-aware Tailwind classes for the heading, list container, and list item message text.

## Changes Made

1. Added `dark:text-white` to the heading `<h2>` element.
2. Added `dark:text-slate-200` to the `<ul>` list container.
3. Added `shrink-0` to the icon `<span>` to prevent icon squishing in flex layout.
4. Added `text-main dark:text-slate-200` to the message `<span>` inside each list item.

## Impact it Made

- All text elements in the Insights card are now explicitly readable in dark mode.
- The card heading and message text have proper color contrast in both light and dark modes.
- Icon span now has `shrink-0` to prevent layout shifts.

## Note: please assign this PR to the `tmdeveloper007` account.
