### PR TITLE
fix : replaced emoji with Link2 icon in TaskItem dependsOn display

### DIFF
--- a/frontend/src/components/Task/TaskItem.jsx
+++ b/frontend/src/components/Task/TaskItem.jsx
@@ -1,8 +1,7 @@
-import { Check, Trash2, Pencil, Calendar, Play } from "lucide-react";
+import { Check, Trash2, Pencil, Calendar, Play, RefreshCw, Link2 } from "lucide-react";
 import { useState } from "react";
 import TaskFormModal from "./TaskFormModal";
 import { getCategoryColor } from "../../utils/categoryUtils";
-import { RefreshCw } from "lucide-react";
 
 const priorityStyles = {
   Low: "border-green-500 bg-green-50 dark:bg-green-950/20",
@@ -104,7 +103,7 @@ export default function TaskItem({
 
               {task.dependsOn && (
                 <div className="text-[11px] text-muted flex items-center gap-1 mt-1 bg-white/40 dark:bg-slate-800/40 px-2 py-1 rounded border border-soft/30">
-                  <span className="shrink-0 text-amber-500">🔗</span>
+                  <span className="shrink-0 text-amber-500"><Link2 size={12} /></span>
                   <span className="truncate" title={task.dependsOn.title}>
                     Depends on: {task.dependsOn.title}
                   </span>
@@ -225,8 +224,9 @@ export default function TaskItem({
               </div>
 
               {task.dependsOn && (
-  <p className="text-xs text-muted mt-1">
-    🔗 Depends on: {task.dependsOn.title}
+  <p className="text-xs text-muted mt-1 flex items-center gap-1">
+    <Link2 size={12} className="text-amber-500" />
+    Depends on: {task.dependsOn.title}
   </p>
 )}
 


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the hardcoded link emoji (🔗) in the `TaskItem.jsx` component with a Lucide `Link2` icon component in both the board view and list view dependency displays.

## Changes Made

1. Added `Link2` to the lucide-react imports in `TaskItem.jsx`.
2. In the board view, replaced `🔗` with `<Link2 size={12} className="text-amber-500" />`.
3. In the list view, replaced `🔗` with `<Link2 size={12} className="text-amber-500" />` and wrapped the text in a flex container with `flex items-center gap-1` for proper icon-text alignment.

## Impact it Made

- Consistent use of vector icons instead of emoji across the task interface.
- Better visual scalability and accessibility.
- Matches the icon-based design language used in other task-related components.
- The amber color (`text-amber-500`) maintains the visual distinction of dependency links.

## Note: please assign this PR to the `tmdeveloper007` account.
