### PR TITLE
feat(routines): Implement drag-and-drop reordering for daily routines (#1301)

### DIFF
--- a/backend/__tests__/routineReorder.test.js
+++ b/backend/__tests__/routineReorder.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reorderRoutines } from '../controllers/routineController.js';
+
+describe('Routine Reorder Controller Unit Tests (#1301)', () => {
+  it('returns 401 when user is unauthenticated', async () => {
+    const req = { userId: null, body: {} };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await reorderRoutines(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false })
+    );
+  });
+
+  it('returns 400 when items parameter is not an array', async () => {
+    const req = { userId: 'user123', body: { items: 'invalid' } };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await reorderRoutines(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Items array is required for reordering' })
+    );
+  });
+});

--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -464,3 +464,65 @@ export const getPublicRoutine = async (req, res) => {
       .json({ success: false, message: "Error fetching public routine" });
   }
 };
+
+// Reorder routines / routine items function
+export const reorderRoutines = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const user = await User.findById(userId);
+    if (!user) {
+      return res
+        .status(401)
+        .json({ success: false, message: "Unauthorized, user not logged in" });
+    }
+
+    const { items, routineId } = req.body;
+    if (!Array.isArray(items)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Items array is required for reordering" });
+    }
+
+    if (routineId) {
+      const routine = await Routine.findOne({ _id: routineId, userId });
+      if (!routine) {
+        return res
+          .status(404)
+          .json({ success: false, message: "Routine not found" });
+      }
+
+      items.forEach((item, index) => {
+        const target = routine.items.id(item.id || item._id) || routine.items[index];
+        if (target) {
+          target.orderIndex = item.orderIndex !== undefined ? item.orderIndex : index;
+        }
+      });
+
+      await routine.save();
+      return res.status(200).json({
+        success: true,
+        message: "Routine items reordered successfully",
+        routine,
+      });
+    }
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      await Routine.updateOne(
+        { _id: item.id || item._id, userId },
+        { $set: { orderIndex: item.orderIndex !== undefined ? item.orderIndex : i } }
+      );
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: "Routines reordered successfully",
+    });
+  } catch (error) {
+    console.log("Error reordering routines", error);
+    return res
+      .status(500)
+      .json({ success: false, message: "Error reordering routines" });
+  }
+};
+

--- a/backend/routes/routineRoutes.js
+++ b/backend/routes/routineRoutes.js
@@ -6,6 +6,7 @@ import {
   getRoutines,
   updateRoutine,
   getPublicRoutine,
+  reorderRoutines,
 } from "../controllers/routineController.js";
 import { authMiddleware } from "../middlewares/authMiddleware.js";
 import asyncHandler from "../middlewares/asyncHandler.js";
@@ -13,6 +14,9 @@ import validateObjectId from "../middlewares/validateObjectId.js";
 
 // router object for routine
 export const routineRouter = express.Router();
+
+// Route for reordering routines / routine items
+routineRouter.put("/reorder", authMiddleware, asyncHandler(reorderRoutines));
 
 // Route for creating routine
 routineRouter.post("/", authMiddleware, asyncHandler(createRoutine));

--- a/backend/src/models/Routine.js
+++ b/backend/src/models/Routine.js
@@ -46,8 +46,16 @@ const routineSchema = mongoose.Schema(
           required: true,
           min: 10,
         },
+        orderIndex: {
+          type: Number,
+          default: 0,
+        },
       },
     ],
+    orderIndex: {
+      type: Number,
+      default: 0,
+    },
     adaptiveSettings: {
       adaptiveEnabled: {
         type: Boolean,

--- a/frontend/src/components/RoutineList.tsx
+++ b/frontend/src/components/RoutineList.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+
+export interface RoutineItem {
+  id: string;
+  _id?: string;
+  name: string;
+  day?: string;
+  duration?: number;
+  orderIndex?: number;
+}
+
+export interface RoutineListProps {
+  routineId?: string;
+  initialItems: RoutineItem[];
+  onReorder?: (items: RoutineItem[]) => void;
+}
+
+export const RoutineList: React.FC<RoutineListProps> = ({
+  routineId,
+  initialItems,
+  onReorder,
+}) => {
+  const [items, setItems] = useState<RoutineItem[]>(initialItems || []);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLLIElement>, index: number) => {
+    e.preventDefault();
+    if (draggedIndex === null || draggedIndex === index) return;
+
+    const newItems = [...items];
+    const [draggedItem] = newItems.splice(draggedIndex, 1);
+    newItems.splice(index, 0, draggedItem);
+
+    // Reassign orderIndex
+    const reordered = newItems.map((item, idx) => ({
+      ...item,
+      orderIndex: idx,
+    }));
+
+    setItems(reordered);
+    setDraggedIndex(index);
+
+    if (onReorder) {
+      onReorder(reordered);
+    }
+  };
+
+  const handleDragEnd = async () => {
+    setDraggedIndex(null);
+    try {
+      await fetch('/api/routines/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          routineId,
+          items: items.map((item, idx) => ({
+            id: item.id || item._id,
+            orderIndex: idx,
+          })),
+        }),
+      });
+    } catch (err) {
+      console.error('Failed to sync reordered routine items:', err);
+    }
+  };
+
+  return (
+    <ul className="routine-list space-y-2">
+      {items.map((item, index) => (
+        <li
+          key={item.id || item._id || index}
+          draggable
+          onDragStart={() => handleDragStart(index)}
+          onDragOver={(e) => handleDragOver(e, index)}
+          onDragEnd={handleDragEnd}
+          className={`p-3 bg-card border border-border rounded-lg cursor-grab active:cursor-grabbing flex items-center justify-between transition-transform ${
+            draggedIndex === index ? 'opacity-50 scale-95' : 'opacity-100'
+          }`}
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-bold text-muted-foreground select-none">
+              ≡ #{index + 1}
+            </span>
+            <span className="font-semibold text-foreground">{item.name}</span>
+          </div>
+          {item.day && (
+            <span className="text-xs px-2 py-1 bg-primary/10 text-primary rounded font-medium">
+              {item.day}
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default RoutineList;


### PR DESCRIPTION
## 📌 Description
Adds drag-and-drop reordering capability for daily routine items. Updates `RoutineList.tsx` frontend component with interactive drag handlers and implements the `/api/routines/reorder` backend API route to persist updated task ordering in the database.

## 🔗 Related Issue
Closes #1301

## 🛠 Changes Made
- Added `/api/routines/reorder` PUT route in `backend/routes/routineRoutes.js` & `routineController.js`.
- Implemented drag-and-drop reorder handlers in `frontend/src/components/RoutineList.tsx`.
- Added unit tests in `backend/__tests__/routineReorder.test.js`.

## 📸 Screenshots (if applicable)
N/A - Logic and backend API integration for routine reordering.

## ✅ Checklist
- [x] Code runs locally
- [x] Followed project structure
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue

## 🚀 Notes for Reviewers
Ensured smooth optimistic UI reordering with persistence to backend DB.