### PR TITLE
fix : added replaced hardcoded text-black in duration completion modals

### DIFF
--- a/frontend/src/components/Dashboard/DashboardTasks.jsx
+++ b/frontend/src/components/Dashboard/DashboardTasks.jsx
@@ -156,13 +156,13 @@ export default function DashboardTasks({ tasks, updateTask }) {
       )}
 
       {durationModalTask && (
-        <div className="fixed inset-0 bg-black/10 flex items-center justify-center z-50 animate-in fade-in duration-200">
-          <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6">
-            <h2 className="text-xl font-semibold mb-2 text-black/90">
+        <div className="fixed inset-0 bg-black/10 dark:bg-black/40 flex items-center justify-center z-50 animate-in fade-in duration-200">
+          <div className="bg-white dark:bg-[#1e293b] rounded-2xl shadow-xl w-full max-w-sm p-6">
+            <h2 className="text-xl font-semibold mb-2 text-main">
               Complete Task
             </h2>
 
-            <p className="text-sm mb-4 text-black">
+            <p className="text-sm mb-4 text-muted">
               How long did you actually take to complete "
               {durationModalTask.title}"?
             </p>
@@ -171,7 +171,7 @@ export default function DashboardTasks({ tasks, updateTask }) {
               min="1"
               value={actualDuration}
               onChange={(e) => setActualDuration(e.target.value)}
-              className="w-full p-2 border border-soft rounded-lg text-black dark:placeholder-slate-500"
+              className="w-full p-2 border border-soft rounded-lg text-gray-900 dark:text-white dark:placeholder-slate-500"
               placeholder="Actual duration in minutes"
             />
             <div className="flex justify-end gap-3 mt-5">
@@ -180,7 +180,7 @@ export default function DashboardTasks({ tasks, updateTask }) {
                   setDurationModalTask(null);
                   setActualDuration("");
                 }}
-                className="px-4 py-2 rounded-lg border border-soft text-black hover:bg-gray-100 transition"
+                className="px-4 py-2 rounded-lg border border-soft text-gray-700 dark:text-gray-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
               >
                 Cancel
               </button>

--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -166,13 +166,13 @@ export default function TaskPreview({ tasks , updateTask}) {
       )}
 
       {durationModalTask && (
-        <div className="fixed inset-0 bg-black/10 flex items-center justify-center z-50 animate-in fade-in duration-200">
-          <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6">
-            <h2 className="text-xl font-semibold mb-2 text-black/90">
+        <div className="fixed inset-0 bg-black/10 dark:bg-black/40 flex items-center justify-center z-50 animate-in fade-in duration-200">
+          <div className="bg-white dark:bg-[#1e293b] rounded-2xl shadow-xl w-full max-w-sm p-6">
+            <h2 className="text-xl font-semibold mb-2 text-main">
               Complete Task
             </h2>
 
-            <p className="text-sm mb-4 text-black">
+            <p className="text-sm mb-4 text-muted">
               How long did you actually take to complete "
               {durationModalTask.title}"?
             </p>
@@ -181,7 +181,7 @@ export default function TaskPreview({ tasks , updateTask}) {
               min="1"
               value={actualDuration}
               onChange={(e) => setActualDuration(e.target.value)}
-              className="w-full p-2 border border-soft rounded-lg text-black dark:placeholder-slate-500"
+              className="w-full p-2 border border-soft rounded-lg text-gray-900 dark:text-white dark:placeholder-slate-500"
               placeholder="Actual duration in minutes"
             />
             <div className="flex justify-end gap-3 mt-5">
@@ -190,7 +190,7 @@ export default function TaskPreview({ tasks , updateTask}) {
                   setDurationModalTask(null);
                   setActualDuration("");
                 }}
-                className="px-4 py-2 rounded-lg border border-soft text-black hover:bg-gray-100 transition"
+                className="px-4 py-2 rounded-lg border border-soft text-gray-700 dark:text-gray-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
               >
                 Cancel
               </button>


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced hardcoded text-black in the Complete Task duration modal with theme-aware classes for dark mode support in both DashboardTasks.jsx and TaskPreview.jsx.

## Changes Made

- Replaced modal bg-white with dark mode variant
- Replaced text-black/90 with text-main
- Replaced text-black (body) with text-muted
- Replaced text-black (input) with dark mode variant
- Replaced text-black (cancel button) with dark mode variant
- Added dark:bg-black/40 to modal backdrop

## Impact it Made

Complete Task modal is readable in dark mode.

Closes #1989

Note: Please assign this PR to the `tmdeveloper007` account.
