### PR TITLE
fix : added timezone-safe date formatting in analyticsController

### DIFF
--- a/backend/controllers/analyticsController.js
+++ b/backend/controllers/analyticsController.js
@@ -3,12 +3,12 @@ import Routine from "../src/models/Routine.js";
 import User from "../src/models/User.js";
 import Journal from "../src/models/Journal.js";
 
-// Helper to format Date to YYYY-MM-DD in user's timezone/local
+// Helper to format Date to YYYY-MM-DD in UTC
 const formatDateString = (date) => {
   const d = new Date(date);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 };
 


### PR DESCRIPTION
## Summary of What Has Been Done

Updated the  helper in  to use UTC-based date methods (, , ) instead of local timezone methods. This ensures date formatting is consistent regardless of the server timezone.

## Changes Made

- Replaced  with 
- Replaced  with 
- Replaced  with 
- Updated the comment to reflect UTC usage

## Impact it Made

Analytics date labels (daily progress, weekly trend, monthly progress) are now computed in UTC, preventing off-by-one day errors when the server runs in a negative UTC offset timezone.

Closes #2002.

## Note: please assign this PR to the `tmdeveloper007` account.
