### PR TITLE
test : added edge case unit tests for verifyFirebaseIdToken

### DIFF
--- a/backend/utils/firebaseAuth.test.js
+++ b/backend/utils/firebaseAuth.test.js
@@ -86,3 +86,72 @@ test("verifyFirebaseIdToken never allows unverified decode in production", async
   );
 });
 
+test("verifyFirebaseIdToken throws on null, undefined, and empty string token", async () => {
+  await withEnv(
+    {
+      FIREBASE_PROJECT_ID: undefined,
+      FIREBASE_AUTH_ALLOW_UNVERIFIED: undefined,
+      NODE_ENV: "test",
+    },
+    async () => {
+      await assert.rejects(
+        () => verifyFirebaseIdToken(null),
+        /Firebase ID token must be a non-empty string/
+      );
+      await assert.rejects(
+        () => verifyFirebaseIdToken(undefined),
+        /Firebase ID token must be a non-empty string/
+      );
+      await assert.rejects(
+        () => verifyFirebaseIdToken(""),
+        /Firebase ID token must be a non-empty string/
+      );
+    }
+  );
+});
+
+test("verifyFirebaseIdToken throws on expired token in unverified dev mode", async () => {
+  const expiredToken = makeFakeJwt({
+    exp: Math.floor(Date.now() / 1000) - 3600,
+    email: "expired@example.com",
+  });
+
+  await withEnv(
+    {
+      FIREBASE_PROJECT_ID: undefined,
+      FIREBASE_AUTH_ALLOW_UNVERIFIED: "true",
+      NODE_ENV: "development",
+    },
+    async () => {
+      await assert.rejects(
+        () => verifyFirebaseIdToken(expiredToken),
+        /expired/
+      );
+    }
+  );
+});
+
+test("verifyFirebaseIdToken throws when token is not a string", async () => {
+  await withEnv(
+    {
+      FIREBASE_PROJECT_ID: undefined,
+      FIREBASE_AUTH_ALLOW_UNVERIFIED: undefined,
+      NODE_ENV: "test",
+    },
+    async () => {
+      await assert.rejects(
+        () => verifyFirebaseIdToken(123),
+        /Firebase ID token must be a non-empty string/
+      );
+      await assert.rejects(
+        () => verifyFirebaseIdToken({}),
+        /Firebase ID token must be a non-empty string/
+      );
+      await assert.rejects(
+        () => verifyFirebaseIdToken([]),
+        /Firebase ID token must be a non-empty string/
+      );
+    }
+  );
+});
+


### PR DESCRIPTION
## Summary of What Has Been Done

Added three new test cases to  to cover edge cases in the  function:

1.  - verifies the function rejects falsy and empty string inputs
2.  - verifies expired tokens are rejected even in dev-mode
3.  - verifies the type guard rejects numbers, objects, and arrays

## Changes Made

Added 69 lines to  including new test blocks using the existing  helper and .

## Impact it Made

Comprehensive edge-case coverage prevents regressions when the Firebase auth code is modified. The tests document the expected behavior for invalid inputs.

Closes #2003.

## Note: please assign this PR to the `tmdeveloper007` account.
