### PR TITLE
fix : added maxLength inputMode and pattern to TOTP input field

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -176,6 +176,9 @@ const Login = () => {
               id="totp"
               placeholder="123456"
               required
+              maxLength={6}
+              inputMode="numeric"
+              pattern="[0-9]{6}"
               value={totpCode}
               onChange={(e) => setTotpCode(e.target.value)}
               className="input-modern w-full px-4 py-3 rounded-2xl text-sm border-1 border-slate-200"


### PR DESCRIPTION
## Summary of What Has Been Done

Added , , and  attributes to the TOTP code input field in .

## Changes Made

Three new attributes added to the TOTP input field:
-  - prevents entering more than 6 characters
-  - triggers numeric keyboard on mobile devices
-  - provides browser-native validation for 6-digit numeric input

## Impact it Made

Users on mobile devices will see the numeric keyboard automatically. The input is bounded to 6 characters, preventing invalid form submissions with too many digits before the request is sent to the server.

Closes #2004.

## Note: please assign this PR to the `tmdeveloper007` account.
