### PR TITLE
fix : added aria-label and aria-checked to TaskItem checkbox for screen reader accessibility

### DIFF
--- a/frontend/src/components/Task/TaskItem.jsx
+++ b/frontend/src/components/Task/TaskItem.jsx
@@ -48,6 +48,8 @@ export default function TaskItem({
                   type="checkbox"
                   checked={isSelected}
                   onChange={() => onSelect(task._id)}
+                  aria-label={`Mark '${task.title}' as ${isCompleted ? "incomplete" : "complete"}`}
+                  aria-checked={isCompleted}
                   className="w-4 h-4 cursor-pointer rounded border-gray-300 text-blue-600 dark:text-slate-100 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-700 accent-(--primary)"
                 />
                 <span className="text-[10px] font-extrabold uppercase tracking-wider px-2 py-0.5 rounded bg-white/70 dark:bg-slate-800/70 text-main shadow-xs border border-soft">


### PR DESCRIPTION
## Summary of What Has Been Done

Added `aria-label` and `aria-checked` attributes to the checkbox input in `frontend/src/components/Task/TaskItem.jsx` to improve screen reader accessibility.

The `aria-label` dynamically describes the action based on the task title and current completion state: `Mark '<task-title>' as complete` or `Mark '<task-title>' as incomplete`. The `aria-checked` attribute accurately reflects the completion status of the task.

## Changes Made

- Added `aria-label` attribute to the checkbox in `TaskItem.jsx` (board view)
- Added `aria-checked={isCompleted}` to reflect the task's completion state
- No visual or behavioral changes to the component

## Impact it Made

- Screen reader users can now understand the purpose of each checkbox in the task list
- Improves WCAG 2.1 AA compliance for the task management interface
- Enables users with visual impairments to independently use the task completion feature

## Note: Please assign this PR to the `tmdeveloper007` account.
