### PR TITLE
fix : added console.error for token verification error in authMiddleware

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -49,7 +49,7 @@ export const authMiddleware = (req, res, next) => {
     next();
   } catch (error) {
     // error handling
-    console.log('Token verification error', error);
+    console.error('Token verification error', error);
 
     // expired token
     if (error.name === 'TokenExpiredError') {


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced `console.log` with `console.error` for the JWT token verification error in the `authMiddleware.js` catch block. Token verification failures are security-relevant events and should be logged at the error level.

## Changes Made

1. `backend/middlewares/authMiddleware.js` line 52: Changed `console.log('Token verification error', error)` to `console.error('Token verification error', error)`.

## Impact it Made

- Token verification failures are properly surfaced in production error tracking systems.
- Security-relevant events are distinguishable from intentional debug output in server logs.
- Aligns with the existing `console.error` pattern used in the same file (line 22 already uses `console.error` for `JWT_SECRET` configuration errors).

Closes #2032

Note: Please assign this PR to the `tmdeveloper007` account.