### PR TITLE
fix : replaced alert with inline error in TaskPreview.jsx duration validation

### DIFF
--- a/frontend/src/components/Dashboard/TaskPreview.jsx
+++ b/frontend/src/components/Dashboard/TaskPreview.jsx
@@ -7,6 +7,7 @@ export default function TaskPreview({ tasks , updateTask}) {
   const navigate = useNavigate();
   const [durationModalTask, setDurationModalTask] = useState(null);
   const [actualDuration, setActualDuration] = useState("");
+  const [durationError, setDurationError] = useState("");
 
   const [now, setNow] = useState(new Date());
 
@@ -50,7 +51,7 @@ export default function TaskPreview({ tasks , updateTask}) {
     const durationValue = Number(actualDuration);
 
     if (Number.isNaN(durationValue) || durationValue <= 0) {
-      alert("Please enter a valid duration in minutes");
+      setDurationError("Please enter a valid duration in minutes");
       return;
     }
 
@@ -180,15 +181,19 @@ export default function TaskPreview({ tasks , updateTask}) {
               type="number"
               min="1"
               value={actualDuration}
-              onChange={(e) => setActualDuration(e.target.value)}
+              onChange={(e) => { setActualDuration(e.target.value); setDurationError(""); }}
               className="w-full p-2 border border-soft rounded-lg text-black dark:placeholder-slate-500"
               placeholder="Actual duration in minutes"
             />
+            {durationError && (
+              <p className="text-sm text-red-500 mt-1">{durationError}</p>
+            )}
             <div className="flex justify-end gap-3 mt-5">
               <button
                 onClick={() => {
                   setDurationModalTask(null);
                   setActualDuration("");
+                  setDurationError("");
                 }}
                 className="px-4 py-2 rounded-lg border border-soft text-black hover:bg-gray-100 transition"
               >


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced the browser alert() call in the TaskPreview component duration modal with a state-based inline error message for better UX.

## Changes Made
- Added durationError state to the TaskPreview component
- Replaced alert() with setDurationError() when validation fails
- Cleared error on input change and modal close
- Added inline error display below the duration input

## Impact it Made
- Eliminates jarring browser dialog
- Works properly on mobile
- Consistent with the app's UX patterns

## Note: Please assign this PR to the tmdeveloper007 account.