### PR TITLE
fix : replaced alert with inline error in Analytics.jsx image export

### DIFF
--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -22,6 +22,7 @@ export default function Analytics() {
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [exportError, setExportError] = useState("");
   const [hoveredBar, setHoveredBar] = useState(null);
   const [hoveredPoint, setHoveredPoint] = useState(null);
 
@@ -95,6 +96,7 @@ export default function Analytics() {
 
   // Image Export Handler
   const exportToImage = async () => {
+    setExportError("");
     const element = document.getElementById("analytics-dashboard-content");
     if (!element) return;
     try {
@@ -118,7 +120,7 @@ export default function Analytics() {
       document.body.removeChild(link);
     } catch (err) {
       console.error("Failed to export image:", err);
-      alert("Failed to export dashboard as image");
+      setExportError("Failed to export dashboard as image");
     }
   };
 
@@ -266,6 +268,9 @@ export default function Analytics() {
             Export PNG
           </button>
         </div>
+        {exportError && (
+          <p className="text-sm text-red-500 w-full">{exportError}</p>
+        )}
       </header>
 
       {/* Grid of Key Metrics */}


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced the browser alert() call in the Analytics page image export handler with a state-based inline error message for better UX.

## Changes Made
- Added exportError state to the Analytics component
- Cleared exportError at the start of exportToImage
- Replaced alert() with setExportError() on catch
- Added inline error display below the export buttons

## Impact it Made
- Eliminates jarring browser dialog on export failure
- Works properly on mobile
- Consistent with the app's UX patterns

## Note: Please assign this PR to the tmdeveloper007 account.