### PR TITLE
fix : added inline error in Analytics export failure

### DIFF
--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -24,6 +24,7 @@ export default function Analytics() {
   const [error, setError] = useState("");
   const [hoveredBar, setHoveredBar] = useState(null);
   const [hoveredPoint, setHoveredPoint] = useState(null);
+  const [imageExportError, setImageExportError] = useState("");
 
   const fetchAnalytics = async () => {
     try {
@@ -118,7 +119,7 @@ export default function Analytics() {
       document.body.removeChild(link);
     } catch (err) {
       console.error("Failed to export image:", err);
-      alert("Failed to export dashboard as image");
+      setImageExportError("Failed to export dashboard as image");
     }
   };
 
@@ -266,6 +267,9 @@ export default function Analytics() {
             Export PNG
           </button>
         </div>
+        {imageExportError && (
+          <p className="text-sm text-red-500 w-full md:w-auto">{imageExportError}</p>
+        )}
       </header>
 
       {/* Grid of Key Metrics */}


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced the `alert()` dialog in `Analytics.jsx` `exportToImage` function with an inline error state. An `imageExportError` state was added to display the error message directly in the header area.

## Changes Made
- Added `imageExportError` state variable to the component
- Replaced `alert()` call in `exportToImage` catch block with `setImageExportError()`
- Added inline error display below the export buttons

## Impact it Made
- Eliminates disruptive browser alert dialogs
- Provides cleaner, more accessible UX
- Error message is visible within context, not dismissed by an alert

Closes #2058

## Note
Please assign this PR to the `tmdeveloper007` account.
