### PR TITLE
fix : changed console.log to console.error in useTasks error handlers

### DIFF
--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -52,7 +52,7 @@ const useTasks = ({
           limit: data.limit || initialLimit,
         });
       } catch (error) {
-        console.log(error?.response?.data?.message || "Failed to load tasks");
+        console.error(error?.response?.data?.message || "Failed to load tasks");
         setTasks([]);
       } finally {
         setLoading(false);
@@ -76,7 +76,7 @@ const useTasks = ({
         setPage(DEFAULT_PAGE);
       }
     } catch (error) {
-      console.log("FULL ERROR:", error);
+      console.error("FULL ERROR:", error);
       console.log(
         error?.response?.data?.message ||
           error?.response?.data ||
@@ -114,7 +114,7 @@ const useTasks = ({
       invalidateTasks();
       await getTasks(page);
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to update task");
+      console.error(error?.response?.data?.message || "Failed to update task");
       invalidateTasks();
       await getTasks(page);
     }


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced `console.log` with `console.error` in error handling paths of `useTasks.js` to ensure proper error severity classification in browser devtools.

## Changes Made
- `getTasks` catch block: changed `console.log` to `console.error`
- `addTask` catch block: changed `console.log("FULL ERROR:", error)` to `console.error`
- `updateTask` catch block: changed `console.log` to `console.error`

## Impact it Made
- Proper error severity in browser devtools logs
- Easier filtering and searching for actual errors
- Consistent error handling across the application

Closes #2060

## Note
Please assign this PR to the `tmdeveloper007` account.
