### PR TITLE
fix : added missing API call to deleteTask and replaced console.log/alert with console.error in useTasks

### DIFF
--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -52,7 +52,7 @@ const useTasks = ({
           limit: data.limit || initialLimit,
         });
       } catch (error) {
-        console.log(error?.response?.data?.message || "Failed to load tasks");
+        console.error(error?.response?.data?.message || "Failed to load tasks");
         setTasks([]);
       } finally {
         setLoading(false);
@@ -76,13 +76,13 @@ const useTasks = ({
         setPage(DEFAULT_PAGE);
       }
     } catch (error) {
-      console.log("FULL ERROR:", error);
-      console.log(
+      console.error("FULL ERROR:", error);
+      console.error(
         error?.response?.data?.message ||
           error?.response?.data ||
           error.message,
       );
-      alert(error?.response?.data?.message || "Failed to create task");
+      console.error(error?.response?.data?.message || "Failed to create task");
       throw error;
     }
   };
@@ -114,7 +114,7 @@ const useTasks = ({
       invalidateTasks();
       await getTasks(page);
     } catch (error) {
-      console.log(error?.response?.data?.message || "Failed to update task");
+      console.error(error?.response?.data?.message || "Failed to update task");
       invalidateTasks();
       await getTasks(page);
     }
@@ -122,10 +122,17 @@ const useTasks = ({
 
   // delete task
   const deleteTask = async (id) => {
-    // Optimistic UI update
-    setTasks((prev) => prev.filter((t) => t._id !== id));
-    invalidateTasks();
-    await getTasks(page);
+    try {
+      await api.delete(`/tasks/${id}`);
+      setTasks((prev) => prev.filter((t) => t._id !== id));
+      invalidateTasks();
+      await getTasks(page);
+      return { success: true, message: "Task deleted successfully" };
+    } catch (error) {
+      console.error(error?.response?.data?.message || "Failed to delete task");
+      await getTasks(page);
+      return { success: false, message: error?.response?.data?.message || "Failed to delete task" };
+    }
   };
 
   // bulk delete tasks


### PR DESCRIPTION
## Summary of What Has Been Done
1. Added the missing `api.delete(\`/tasks/${id}\`)` call to the `deleteTask` function in `frontend/src/hooks/useTasks.js`. Previously, the function only updated the UI optimistically but never actually deleted the task from the database.

2. Replaced all `console.log` calls used for error logging with `console.error` in the `getTasks`, `addTask`, and `updateTask` error handlers.

3. Replaced the `alert()` popup in `addTask` with `console.error()` since the error is already thrown and can be handled by the calling component.

## Changes Made
- `frontend/src/hooks/useTasks.js`: Added `api.delete()` call in `deleteTask`, replaced `console.log` with `console.error`, replaced `alert()` with `console.error()`.

## Impact it Made
- Fixes the delete task functionality so tasks are actually removed from the backend database.
- Ensures error conditions are properly logged as errors rather than info messages.
- Removes intrusive browser alert popups from task creation.

Closes #2066
Closes #2069
Closes #2070

## Note: Please assign this PR to the `tmdeveloper007` account.