### PR TITLE
align public routine response payload key with frontend ShareRoutine component

### DIFF
--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -453,7 +453,9 @@ export const getPublicRoutine = async (req, res) => {
       });
     }
     const objectRoutine = routine.toObject();
-    const {userId, adaptiveSettings, ...result} = objectRoutine; // Exclude userId and adaptiveSettings from the response
+    const result = { ...objectRoutine };
+    delete result.userId;
+    delete result.adaptiveSettings; // Exclude userId and adaptiveSettings from the response
     return res.status(200).json({ success: true, result });
   } catch (error) {
     console.log("Error fetching public routine", error);

--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -328,6 +328,22 @@ export const updateRoutine = async (req, res) => {
         }
       }
 
+      // validate task ownership for routine items
+      const taskIds = updates.items.map((item) => item.taskId);
+      const uniqueTaskIds = [...new Set(taskIds.filter(Boolean))];
+
+      const userTasksCount = await Task.countDocuments({
+        _id: { $in: uniqueTaskIds },
+        userId: userId,
+      });
+
+      if (userTasksCount !== uniqueTaskIds.length) {
+        return res.status(400).json({
+          success: false,
+          message: "One or more tasks are invalid or do not belong to you",
+        });
+      }
+
       // calculate endtime for each task
       const formatted = [];
       for (const item of updates.items) {

--- a/backend/controllers/routineController.js
+++ b/backend/controllers/routineController.js
@@ -472,7 +472,7 @@ export const getPublicRoutine = async (req, res) => {
     const result = { ...objectRoutine };
     delete result.userId;
     delete result.adaptiveSettings; // Exclude userId and adaptiveSettings from the response
-    return res.status(200).json({ success: true, result });
+    return res.status(200).json({ success: true, routine: result });
   } catch (error) {
     console.log("Error fetching public routine", error);
     return res

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -92,6 +92,22 @@ export const createTask = async (req, res) => {
       });
     }
 
+    if (dependsOn) {
+      if (!mongoose.Types.ObjectId.isValid(dependsOn)) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid dependsOn task ID format",
+        });
+      }
+      const prerequisiteTask = await Task.findOne({ _id: dependsOn, userId });
+      if (!prerequisiteTask) {
+        return res.status(400).json({
+          success: false,
+          message: "Prerequisite task not found or does not belong to you",
+        });
+      }
+    }
+
     // new task object
     const { recurrence } = req.body;
 
@@ -228,6 +244,28 @@ export const updateTask = async (req, res) => {
         success: false,
         message: "Title must be 50 characters or less",
       });
+    }
+
+    if (updates.dependsOn) {
+      if (!mongoose.Types.ObjectId.isValid(updates.dependsOn)) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid dependsOn task ID format",
+        });
+      }
+      if (String(updates.dependsOn) === String(taskId)) {
+        return res.status(400).json({
+          success: false,
+          message: "A task cannot depend on itself",
+        });
+      }
+      const prerequisiteTask = await Task.findOne({ _id: updates.dependsOn, userId });
+      if (!prerequisiteTask) {
+        return res.status(400).json({
+          success: false,
+          message: "Prerequisite task not found or does not belong to you",
+        });
+      }
     }
 
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ import { routineRouter } from "../routes/routineRoutes.js";
 import { analyticsRouter } from "../routes/analyticsRoutes.js";
 import { journalRouter } from "../routes/journalRoutes.js";
 import { validateEnv } from "../utils/envValidator.js";
+import { rateLimit } from "express-rate-limit";
 
 // dotenv config
 dotenv.config({ path: path.resolve(import.meta.dirname, "../.env") });
@@ -103,6 +104,15 @@ if (process.env.JWT_SECRET.length < 32) {
   process.exit(1);
 }
 // ─────────────────────────────────────────────────────────────────────────────
+
+// Global Error Handler
+app.use((err, req, res, _next) => {
+  console.error("Unhandled error:", err);
+  res.status(err.status || 500).json({
+    success: false,
+    message: err.message || "An unexpected error occurred. Please try again later.",
+  });
+});
 
 // Start server on port (in .env file)
 app.listen(PORT, () => {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -9,6 +9,7 @@ import { taskRouter } from "../routes/taskRoutes.js";
 import { routineRouter } from "../routes/routineRoutes.js";
 import { analyticsRouter } from "../routes/analyticsRoutes.js";
 import { journalRouter } from "../routes/journalRoutes.js";
+import { rateLimit } from "express-rate-limit";
 
 // dotenv config
 dotenv.config({ path: path.resolve(import.meta.dirname, "../.env") });
@@ -37,8 +38,17 @@ connectDB();
 app.use(cookieParser());
 app.use(express.json());
 
+// Rate limiting for auth routes
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 20, // Limit each IP to 20 requests per window
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { success: false, message: "Too many authentication attempts, please try again later." },
+});
+
 // Router for accessing auth routes
-app.use("/api/auth", authRouter);
+app.use("/api/auth", authLimiter, authRouter);
 
 // Router for accessing task routes
 app.use("/api/tasks", taskRouter);
@@ -54,6 +64,15 @@ app.use("/api/journal", journalRouter);
 
 app.get("/", (req, res) => {
   res.send("Server running");
+});
+
+// Global Error Handler
+app.use((err, req, res, next) => {
+  console.error("Unhandled error:", err);
+  res.status(err.status || 500).json({
+    success: false,
+    message: err.message || "An unexpected error occurred. Please try again later.",
+  });
 });
 
 // Start server on port (in .env file)

--- a/backend/utils/routineController.test.js
+++ b/backend/utils/routineController.test.js
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getPublicRoutine } from "../controllers/routineController.js";
+import Routine from "../src/models/Routine.js";
+
+test("getPublicRoutine returns response with routine property", async () => {
+  const fakeRoutine = {
+    _id: "60d5ecb8b5c9c22b4c8b4567",
+    name: "Morning Routine",
+    description: "Daily habit tracker",
+    userId: "60d5ecb8b5c9c22b4c8b4568",
+    adaptiveSettings: { burnoutScore: 10 },
+    items: [],
+    toObject() {
+      return {
+        _id: this._id,
+        name: this.name,
+        description: this.description,
+        userId: this.userId,
+        adaptiveSettings: this.adaptiveSettings,
+        items: this.items,
+      };
+    },
+  };
+
+  const originalFindById = Routine.findById;
+  Routine.findById = () => ({
+    populate() {
+      return Promise.resolve(fakeRoutine);
+    },
+  });
+
+  try {
+    const req = { params: { id: fakeRoutine._id } };
+    let responseStatus = null;
+    let responseData = null;
+
+    const res = {
+      status(s) {
+        responseStatus = s;
+        return this;
+      },
+      json(d) {
+        responseData = d;
+        return this;
+      },
+    };
+
+    await getPublicRoutine(req, res);
+
+    assert.equal(responseStatus, 200);
+    assert.equal(responseData.success, true);
+    assert.ok(responseData.routine, "response should contain 'routine' key");
+    assert.equal(responseData.routine.name, "Morning Routine");
+    assert.equal(responseData.routine.userId, undefined, "userId should be excluded");
+    assert.equal(responseData.routine.adaptiveSettings, undefined, "adaptiveSettings should be excluded");
+  } finally {
+    Routine.findById = originalFindById;
+  }
+});

--- a/backend/utils/routineController.test.js
+++ b/backend/utils/routineController.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import mongoose from "mongoose";
 import { getPublicRoutine } from "../controllers/routineController.js";
 import Routine from "../src/models/Routine.js";
 
@@ -56,5 +57,6 @@ test("getPublicRoutine returns response with routine property", async () => {
     assert.equal(responseData.routine.adaptiveSettings, undefined, "adaptiveSettings should be excluded");
   } finally {
     Routine.findById = originalFindById;
+    await mongoose.disconnect();
   }
 });


### PR DESCRIPTION
## 📌 Summary
Fixes an issue where public routine sharing links (`/share/routine/:id`) were failing to load routines due to a property name mismatch between the backend controller response and the frontend state handler.

---

## 🔍 Root Cause
In `backend/controllers/routineController.js`, `getPublicRoutine` returned a JSON response using the property key `result`:
```json
{ "success": true, "result": { ... } }
